### PR TITLE
Support DOWNTO keyword

### DIFF
--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -648,7 +648,7 @@
 				},
 				{
 					"name": "keyword.other.rpgle",
-					"match": ":|\\.|\\,|\\*{1,2}(=)?|=|<>|((<|>|\\+|\\-|\\/)(=)?)|((\\b(?i)(TO|AND|OR|NOT)\\b))"
+					"match": ":|\\.|\\,|\\*{1,2}(=)?|=|<>|((<|>|\\+|\\-|\\/)(=)?)|((\\b(?i)(TO|DOWNTO|AND|OR|NOT)\\b))"
 				},
 				{
 					"name": "keyword.other.rpgle.bif",


### PR DESCRIPTION
RPGLE `FOR` operations not only supports the `TO` keyword, it also supports `DOWNTO`.

https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_74/rzasd/zzfor.htm

```
    dcl-s field char(50) inz('hello world');
    for i = %len (field) downto 1;
       if %subst(field: i: 1) = ' ';
          iter;
       endif;
       dsply (%subst(field: i: 1));
    endfor;
```