### PR TITLE
Add cobol textmate language and configuration.

### DIFF
--- a/configurations/cobol.language-configuration.json
+++ b/configurations/cobol.language-configuration.json
@@ -1,11 +1,3 @@
-/*******************************************************************************
- * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corporation 2019. All Rights Reserved.
- *
- * Note to U.S. Government Users Restricted Rights:
- * Use, duplication or disclosure restricted by GSA ADP Schedule
- * Contract with IBM Corp.
- *******************************************************************************/
  {
     "comments": {
       "lineComment": "      *"

--- a/configurations/cobol.language-configuration.json
+++ b/configurations/cobol.language-configuration.json
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Licensed Materials - Property of IBM
+ * (C) Copyright IBM Corporation 2019. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ *******************************************************************************/
+ {
+    "comments": {
+      "lineComment": "      *"
+    },
+    "brackets": [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"]
+    ],
+    "autoClosingPairs": [
+      { "open": "{", "close": "}" },
+      { "open": "[", "close": "]" },
+      { "open": "(", "close": ")" },
+      { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+      { "open": "\"", "close": "\"", "notIn": ["string"] },
+      { "open": "`", "close": "`", "notIn": ["string", "comment"] },
+      { "open": "/**", "close": " */", "notIn": ["string"] }
+    ],
+    "autoCloseBefore": ";:.,=}])>` \n\t",
+    "surroundingPairs": [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"],
+      ["'", "'"],
+      ["\"", "\""],
+      ["`", "`"]
+    ],
+    "folding": {
+      "markers": {
+        "start": "^\\s*\\$region\\b",
+        "end": "^\\s*\\$end-region\\b"
+      }
+    },
+    "wordPattern": "[a-zA-Z0-9_-]+"
+  }
+  

--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
 					".cbl38",
 					".cblle",
 					".sqlcbl",
-					".sqlcblle",
-					".pgm.sqlcblle",
-					".srvpgm.sqlcblle"
+					".sqlcblle"
 				],
 				"configuration": "./configurations/cobol.language-configuration.json"
 			},

--- a/package.json
+++ b/package.json
@@ -44,6 +44,22 @@
                 "configuration": "./configurations/cl.language-configuration.json"
             },
             {
+				"id": "cobol",
+				"aliases": [
+					"cobol"
+				],
+				"extensions": [
+					".cbl",
+					".cbl38",
+					".cblle",
+					".sqlcbl",
+					".sqlcblle",
+					".pgm.sqlcblle",
+					".srvpgm.sqlcblle"
+				],
+				"configuration": "./configurations/cobol.language-configuration.json"
+			},
+            {
                 "id": "cmd",
                 "aliases": [
                     "CMD",
@@ -170,6 +186,11 @@
                 "scopeName": "source.cl",
                 "path": "./syntaxes/cl.tmLanguage.json"
             },
+            {
+				"language": "cobol",
+				"scopeName": "source.cobol",
+				"path": "./syntaxes/cobol.tmLanguage.json"
+			},
             {
                 "language": "cmd",
                 "scopeName": "source.cmd",

--- a/syntaxes/cobol.tmLanguage.json
+++ b/syntaxes/cobol.tmLanguage.json
@@ -1,0 +1,589 @@
+{
+    "fileTypes": ["cbl", "cpy", "cob"],
+    "name": "COBOL",
+    "patterns": [
+      {
+        "match": "(^.{6})(\\*.*$)",
+        "name": "comment.line.cobol.fixed"
+      },
+      {
+        "match": "(^.{6})(\\/.*$)",
+        "name": "comment.line.cobol.fixed"
+      },
+  
+      {
+        "match": "(?:^|\\s+)(?i:\\$\\s*set\\s+)(ilusing.*)$",
+        "captures": {
+          "0": {
+            "name": "comment.line.set.cobol"
+          },
+          "1": {
+            "name": "keyword.control.import"
+          },
+          "2": {
+            "name": "comment.line.set.cobol"
+          }
+        }
+      },
+      {
+        "match": "(?:^|\\s+)(?i:\\$\\s*set\\s)((?i:01SHUFFLE|64KPARA|64KSECT|AUXOPT|CHIP|DATALIT|EANIM|EXPANDDATA|FIXING|FLAG-CHIP|MASM|MODEL|OPTSIZE|OPTSPEED|PARAS|PROTMODE|REGPARM|SEGCROSS|SEGSIZE|SIGNCOMPARE|SMALLDD|TABLESEGCROSS|TRICKLECHECK|\\s)+).*$",
+        "captures": {
+          "0": {
+            "name": "comment.line.set.cobol.1"
+          },
+          "1": {
+            "name": "invalid.illegal.directive"
+          },
+          "2": {
+            "name": "comment.line.set.cobol.2"
+          }
+        }
+      },
+      {
+        "match": "(?:^|\\s+)(?i:\\$\\s*set\\s|>>cbl\\s)(.*)$",
+        "captures": {
+          "0": {
+            "name": "comment.line.set.cobol"
+          },
+          "1": {
+            "name": "variable.cobol"
+          },
+          "2": {
+            "name": "comment.line.set.cobol"
+          }
+        }
+      },
+      {
+        "match": "\\$(?i:if|else|then|display|xfd|end)(.*$)",
+        "name": "meta.preprocessor"
+      },
+      {
+        "match": "(?:^|\\s+)>>(?i:if|else|elif|end-if)(?:$|\\s.*$)",
+        "name": "invalid.illegal.cobol"
+      },
+      {
+        "match": "(\\*>.*$)",
+        "name": "comment.line.modern"
+      },
+      {
+        "match": "(>>.*)$",
+        "name": "strong comment.line.set.acucobol"
+      },
+      {
+        "match": "([nN][xX]|[hHxX])'\\h*'",
+        "name": "constant.numeric.integer.hexadecimal.cobol"
+      },
+      {
+        "match": "([nN][xX]|[hHxX])'.*'",
+        "name": "invalid.illegal.hexadecimal.cobol"
+      },
+      {
+        "match": "([nN][xX]|[hHxX])\"\\h*\"",
+        "name": "constant.numeric.integer.hexadecimal.cobol"
+      },
+      {
+        "match": "([nN][xX]|[hHxX])\".*\"",
+        "name": "invalid.illegal.hexadecimal.cobol"
+      },
+      {
+        "match": "[oO]\"[0-7]*\"",
+        "name": "constant.numeric.integer.octal.cobol"
+      },
+      {
+        "match": "[oO]\".*\"",
+        "name": "invalid.illegal.octal.cobol"
+      },
+      {
+        "match": "(#)([0-9a-zA-Z][a-zA-Z\\-0-9]+)",
+        "name": "meta.symbol.cobol.forced"
+      },
+      {
+        "match": "((?<![-_])((?i:installation|author|source-computer|object-computer|date-written|security|date-compiled)\\.)(.*))",
+        "captures": {
+          "1": {
+            "name": "keyword.verb.cobol"
+          },
+          "2": {
+            "name": "keyword.verb.cobol"
+          },
+          "3": {
+            "name": "comment.line.cobol.ignored"
+          }
+        },
+        "end": "(\\.)"
+      },
+      {
+        "match": "(?<=(\\(|\\[))((\\-\\+)*[0-9 ,\\.\\+\\-\\*\\/]+)(?=(\\)|\\]))",
+        "name": "constant.numeric.cobol",
+        "captures": {
+          "1": {
+            "name": "keyword.start.bracket.cobol"
+          },
+          "2": {
+            "name": "constant.numeric.cobol"
+          },
+          "3": {
+            "name": "keyword.end.bracket.cobol"
+          }
+        },
+        "comment": "simple numerics in () and []"
+      },
+      {
+        "match": "(\\-|\\+)?((([0-9]+(\\.[0-9]+))|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?(?=\\s|\\.$|,|\\))",
+        "name": "constant.numeric.cobol"
+      },
+      {
+        "match": "(\\-|\\+)?([0-9]+)(?=\\s|\\.$|,|\\))",
+        "name": "constant.numeric.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:true|false|null|nulls)(?=\\s|\\.|\\)|$)",
+        "name": "constant.language.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:zeroes|alphabetic-lower|alphabetic-upper|alphanumeric-edited|alphabetic|alphabet|alphanumeric|zeros|zeros|zero|spaces|space|quotes|quote|low-values|low-value|high-values|high-value)(?=\\s+|\\.|,|\\))",
+        "name": "constant.language.figurative.cobol"
+      },
+      {
+        "begin": "(?i:exec\\s+sql)",
+        "name": "string.quoted.cobol.sql",
+        "patterns": [
+          {
+            "match": "(\\:([0-9a-zA-Z\\-_])*)",
+            "name": "variable.cobol"
+          },
+          {
+            "include": "source.sql"
+          }
+        ],
+        "end": "(?i:end\\-exec)",
+        "endCaptures": "string.quoted.cobol.sql"
+      },
+      {
+        "begin": "(?i:exec\\s+cics)",
+        "name": "string.quoted.cobol.cics",
+        "patterns": [
+          {
+            "match": "(\\()(.*)(\\))",
+            "captures": {
+              "1": {
+                "name": "keyword.start.bracket.cobol"
+              },
+              "2": {
+                "name": "variable.cobol"
+              },
+              "3": {
+                "name": "keyword.end.bracket.cobol"
+              }
+            }
+          }
+        ],
+        "end": "(?i:end\\-exec)",
+        "endCaptures": "string.quoted.cobol.cics"
+      },
+      {
+        "begin": "(?i:exec\\s+sqlims)",
+        "name": "string.quoted.cobol.sqlims",
+        "patterns": [
+          {
+            "match": "(\\:([a-zA-Z\\-])*)",
+            "name": "variable.cobol"
+          },
+          {
+            "include": "source.sql"
+          }
+        ],
+        "end": "(?i:end\\-exec)",
+        "endCaptures": "string.quoted.cobol.sqlims"
+      },
+      {
+        "begin": "(?i:exec\\s+ado)",
+        "name": "string.quoted.cobol.ado",
+        "patterns": [
+          {
+            "match": "(\\:([a-zA-Z\\-])*)",
+            "name": "variable.cobol"
+          },
+          {
+            "include": "source.sql"
+          }
+        ],
+        "end": "(?i:end\\-exec)",
+        "endCaptures": "string.quoted.cobol.ado"
+      },
+      {
+        "begin": "(?i:exec\\s+html)",
+        "name": "string.quoted.cobol.html",
+        "patterns": [
+          {
+            "include": "text.html.basic"
+          },
+          {
+            "include": "text.html.basic"
+          }
+        ],
+        "end": "(?i:end\\-exec)",
+        "endCaptures": "string.quoted.cobol.html"
+      },
+      {
+        "begin": "\"",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "(\"|$)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.double.cobol"
+      },
+      {
+        "begin": "'",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "('|$)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.single.cobol"
+      },
+      {
+        "begin": "[zZ]\"",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "(\"|$)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.double.cobol"
+      },
+      {
+        "begin": "[zZ]'",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "'",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.single.cobol"
+      },
+      {
+        "begin": "[nN]\"",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "(\"|$)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.double.cobol"
+      },
+      {
+        "begin": "[nN]'",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.cobol"
+          }
+        },
+        "end": "'",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.cobol"
+          }
+        },
+        "name": "string.quoted.single.cobol"
+      },
+      {
+        "match": "(?i:id\\s+division|identification\\s+division|identification|property-id|getter|setter|entry|function-id|end\\s+attribute|attribute|interface-id|indexer-id|factory|ctl|class-control|options|environment\\s+division|environment-name|environment-value|environment|configuration\\s+section|configuration|decimal-point\\s+is|decimal-point|console\\s+is|call-convention|special-names|cursor\\s+is|update|picture\\s+symbol|currency\\s+sign|currency|repository|input-output\\s+section|input-output|file\\s+section|file-control|select|optional|i-o-control|data\\s+division|working-storage\\s+section|working-storage|section|local-storage|linkage\\s+section|linkage|communication|report|screen\\s+section|object-storage|object\\s+section|class-object|fd|rd|cd|sd|printing|procedure\\s+division|procedure|references|debugging|end\\s+declaratives|declaratives|end\\s+static|end\\s+factory|end\\s+class-object|based-storage|size|font|national-edited|national)(?=\\s|\\.)",
+        "name": "keyword.identifiers.cobol"
+      },
+      {
+        "match": "(?i:enum-id|valuetype-id|operator-id|method-id|class-id|program-id|attribute-id|iterator-id|implements|inherits|constraints|constrain)(?=\\s|\\.)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:end\\s+enum|end\\s+interface|end\\s+class|end\\s+property|end\\s+method|end\\s+object|end\\s+iterator|end\\s+function|end\\s+operator|end\\s+program|end\\s+indexer|create|reset|instance|delegate|end-delegate|delegate-id|declare|exception-object|json-code|as|stop\\s+run|stop)(?=\\s|\\.|,|\\))",
+        "name": "keyword.identifiers.cobol"
+      },
+      {
+        "match": "\\s+(?i:attach\\s+method|attach\\s+del|attach|detach\\s+del|detach\\s+method|detach|method|del)(?=\\s|\\.|$)",
+        "name": "keyword.identifiers.cobol"
+      },
+      {
+        "match": "\\s+(?i:sync\\s+(?i:on))(?=\\s|\\.)",
+        "name": "keyword.other.sync.cobol"
+      },
+      {
+        "match": "\\s+(?i:try|finally|catch|end-try|throw)(?=\\s|\\.|$)",
+        "name": "keyword.control.catch-exception.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:select|use|thru|varying|giving|remainder|tallying|through|until|execute|returning|using|\\+\\+include|copy|replace)(?=\\s)",
+        "name": "keyword.otherverbs.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:assign|external|organization|indexed|column|plus|line\\*s*sequential|sequential|access|dynamic|relative|label|block|contains|standard|records|record\\s+key|record|is|alternate|duplicates|reel|tape|terminal|disk\\sfilename|disk|disc|recording\\smode|mode|random)(?=\\s|\\.)",
+        "name": "keyword.identifers.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:function)\\s(?i:max|min|integer-of-date|integer-of-day|integer-part|integer|date-to-yyyymmdd|year-to-yyyy|day-to-yyyyddd|exp|exception-file|exception-location|exception-statement|exception-status|e|variance|integer-of-date|rem|pi|factorial|sqrt|log10|fraction-part|mean|exp|log|char|day-of-integer|date-of-integer|exp10|atan|integer-part|tan|sin|cos|midrange|addr|acos|asin|annuity|present-value|integer-of-day|ord-max|ord-min|ord|random|integer-of-date|sum|sign|standard-deviation|median|reverse|abs|upper-case|lower-case|char-national|numval|mod|range|length|locale-date|locale-time-from-seconds|locale-time|seconds-past-midnight|stored-char-length|substitute-case|substitute|seconds-from-formatted-time|seconds=past-midnight|trim|length-an|numval-c|current-date|national-of|display-of|when-compiled|integer-of-boolean|combined-datetime|concatenate)(?=\\s|\\.|\\(|\\)|$)",
+        "name": "support.function.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:function)(?=\\s|\\.)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:end-accept|end-add|end-sync|end-compute|end-delete|end-display|end-divide|end-set|end-multiply|end-of-page|end-read|end-receive|end-return|end-rewrite|end-search|end-start|end-string|end-subtract|end-unstring|end-write|program|class|interface|enum|interface)(?=\\s|\\.)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(?<![-_])(?:by value|by reference|by content|property-value)(?=\\s|\\.)",
+        "name": "keyword.other.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:attr-string|automatic|auto-skip|footing|next|group|indicate|source|control|full|required|of|input|output|i-o|extend|file|error|exception|overflow|goto|off|on|proceed|procedures|procedure|through|invalid|data|normal|eop|returning|to|for|giving|into|by|remainder|also|numeric|free|depending|converting|replacing|after|before|all|leading|first|recursive|initialized|global|common|initial|resident|reference|content|are|renames|like|format\\stime|values|omitted|value|ascending|descending|key|retry|until|varying|with|no|advancing|up|down|uccurs|ignore\\s+lock|lock|length|delimited|count|delimiter|redefines|from\\s+console|from\\s+command-line|from\\s+user\\s+name|from\\s+day\\s+yyyyddd|from\\s+day|from\\s+time|from\\s+day-of-week|from\\s+escape|from\\s+day\\s+yyyyddd|from\\s+date\\s+yyyymmdd|from\\s+date|from|raising|crt\\s+status|status|class|upon\\s+crt|upon|lines|linage|auto|line|position|col|reports|code-set|reporting|arithmetic|localize|program|class|interface|in|at\\s+end|page|name)(?=\\s|\\.|,)",
+        "name": "keyword.identifers.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:type|new)\\s+([a-zA-Z][a-zA-Z0-9\\$\\-\\._]*|[a-zA-Z])(?=\\.$)",
+        "captures": {
+          "0": {
+            "name": "keyword.verbs.cobol"
+          },
+          "1": {
+            "name": "storage.type.cobol"
+          }
+        },
+        "comment": "type ssss "
+      },
+      {
+        "match": "(?<![-_])(?i:string)(?=\\s+value|\\.)",
+        "name": "storage.type.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:bit|binary-char|binary-char-unsigned|binary-short|binary-short-unsigned|binary.long|binary-c-long|binary-long-unsigned|binary-long|binary-double|binary-double-unsigned|float-short|float-extended|float-long|bit|condition-value|characters|character\\s+type|character|comma|crt|decimal|object\\+sreference|object-reference|object|list|dictionary|unsigned)(?=\\s|\\.|,|\\]|\\[)",
+        "name": "storage.type.cobol"
+      },
+      {
+        "match": "(operator-id\\s+[+\\-\\*\\/])",
+        "name": "keyword.operator-id.cobol",
+        "captures": {
+          "1": {
+            "name": "keyword.other.verb.cobol"
+          },
+          "2": {
+            "name": "meta.symbol.cobol"
+          }
+        },
+        "comment": "operator-id ssss "
+      },
+      {
+        "match": "(?i:self)(\\:\\:)([0-9a-zA-Z_\\-\\.]*)(?=\\.$)",
+        "captures": {
+          "1": {
+            "name": "punctuation.accessor.cobol.b3"
+          },
+          "2": {
+            "name": "entity.name.function.b3"
+          }
+        },
+        "comment": " ::.. "
+      },
+      {
+        "match": "(\\:\\:)([0-9a-zA-Z_\\-\\.]*)",
+        "captures": {
+          "1": {
+            "name": "punctuation.accessor.cobol"
+          },
+          "2": {
+            "name": "entity.name.function.cobol"
+          }
+        },
+        "comment": " ::.. "
+      },
+      {
+        "match": "(?<![-_])(?i:type)\\s+([0-9a-zA-Z\\.]*)",
+        "captures": {
+          "0": {
+            "name": "keyword.verbs.cobol.aa"
+          },
+          "1": {
+            "name": "storage.type.cobol.bb"
+          }
+        }
+      },
+      {
+        "match": "(?<![-_])(?i:if|else|end-if|exit\\s+program|exit\\s+method|evaluate|end-evaluate|perform|end-perform|when\\s+other|when|continue|call|end-call|invoke|go\\s+to|go|sort|merge|use|xml|parse|stop\\s+run|goback|raise|exit\\s+function)(?=\\s|\\.|$)",
+        "name": "keyword.control.cobol"
+      },
+  
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBxXpPnNzZ/,.]*\\([0-9]*\\)[vV][-+sS\\*$09aAbBxXpPnNzZ/,\\.]*\\([0-9]*\\)[-|+]",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBxXpPnNzZ/,.]*\\([0-9]*\\)[vV][-+sS\\*$09aAbBxXpPnNzZ/,\\.]*\\([0-9]*\\)",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBxXpPnNzZ/,.]*\\([0-9]*\\)[vV\\.][-+s\\*$09aAbBsSnNxXzZ/,]*[0-9]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBsSnpPNxXzZ/,.]*\\([0-9]*\\)[Vv\\.][-+s\\*0$9aAbBsSnNxpPXzZ/,]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBsSnpPNxXzZ/,.]*\\([0-9]*\\)[-+s\\*0$9aAbBsSnNxpPXzZ/,]*[Vv\\.][-+s\\*0$9aAbBsSnNxpPXzZ/,]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBsSnpPNxXzZ/,.]*\\([0-9]*\\)[-+s\\*0$9aAbBsSnNxpPXzZ/,]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+sS\\*$09aAbBsSnpNNxXzZ/,.]*\\([0-9]*\\)",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[sS]?[9aAbBsSnNxXzZ]*[Vv][9aAxbXzZ]*\\([0-9]*\\)",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[sS]?[9aAbBsSnNxXzZ]*[Vv][9aAxbXzZ]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:picture\\s+is|picture|pic\\s+is|pic)\\s+[-+\\*$9aAbBsSnpPNxXzZ/,.vV]*",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:computational-1|comp-1|computational-2|comp-2|computational-3|comp-3|computational-4|comp-4|computational-x|comp-x|computational-5|comp-5|computational-6|comp-6|computational-n|comp-n|packed-decimal|index|float|double|signed-short|unsigned-short|signed-int|unsigned-int|signed-long|unsigned-long|comp|computational|usage\\sis\\sdisplay|usage\\sis\\sfont|usage display|binary|mutex-pointer|data-pointer|thread-pointer|sempahore-pointer|event-pointer|program-pointer|procedure-pointer|pointer|window|subwindow|control-type|thread|menu|variant|layout-manager|occurs|typedef|any|times|display\\s+blank\\s+when|blank\\s+when|blank\\s+screen|blank|usage\\sis|is\\spartial|usage|justified|just|right|signed|trailing\\s+separate|sign|seperate)(?=\\s|\\.)",
+        "name": "storage.type.picture.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:accept|add|address|allocate|call|cancel|chain|close|commit|compute|continue|delete|disable|display|bell|divide|eject|enable|enter|evaluate|exhibit|named|exit|free|generate|go\\s+to|initialize\\sonly|initialize|initiate|inspect|merge|end-set|set|end-invoke|invoke\\s+run|invoke|move|corresponding|corr|multiply|otherwise|open|sharing|sort-merge|purge|ready|read|receive|release|return|rewrite|rounded|rollback|search|send|sort|collating\\s+sequence|collating|start|service|subtract|suppress|terminate|then|unlock|string|unstring|validate|write|next|statement|sentence)(?=\\s|\\.|$)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(\\s+|^)(?i:foreground-color|background-color|prompt|underline|reverse-video|no-echo|highlight|blink)",
+        "name": "keyword.screens.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:internal|public|protected|final|private|static|new|abstract|override|readonly|property)(?=\\s|\\.)",
+        "name": "storage.modifier.cobol"
+      },
+      {
+        "match": "\\s+(?i:=|<|>|<=|>=|<>|\\+|\\-|\\*|\\/|b-and|b-or|b-xor|b-exor|b-not|b-left|b-right|and|or|equals|equal|greater\\s+than|less\\s+than|greater)(?=\\s+|\\.|$)",
+        "name": "keyword.operator.cobol"
+      },
+      {
+        "match": "(?i:not\\s+at\\s+end)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(?i:not)(?=\\s+|\\.|$)",
+        "name": "keyword.operator.cobol"
+      },
+      {
+        "match": "(?!-)(?i:installation|author|source-computer|object-computer|date-written|date-compiled)(?=\\s|\\.)",
+        "name": "keyword.verbs.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:sysout-flush|sysin|stderr|stdout|csp|stdin|sysipt|sysout|sysprint|syslist|syslst|printer|syserr|console|c01|c02|c03|c04|c05|c06|c07|c08|c09|c10|c11|c12|formfeed|switch-0|switch-10|switch-11|switch-12|switch-13|switch-13|switch-14|switch-15|switch-1|switch-2|switch-3|switch-4|switch-5|switch-6|switch-7|switch-8|switch-9|sw0|sw11|sw12|sw13|sw14|sw15|sw1|sw2|sw3|sw4|sw5|sw6|sw7|sw8|sw9|sw10|lc_all|lc_collate|lc_ctype|lc_messages|lc_monetary|lc_numeric|lc_time|ucs-4|utf-8|utf-16)(?=\\s|\\.|$)",
+        "name": "support.type.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:end-xml|processing.*procedure|xml\\sparse|xml|xml-information|xml-text|xml-schema|xml-ntext|xml-namespace|xml-namespace-prefix|xml-event|xml-declaration|xml-code|xml-nnamespace-prefix|xml-nnamespace)(?=\\s|\\.|$)",
+        "name": "keyword.xml.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:json\\s+generate|json|end-json|name\\sof)(?=\\s|\\.|$)",
+        "name": "keyword.json.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:modify|inquire|title|event|center|label-offset|cell|help-id|cells|push-button|list-box|label|default-font|id|no-tab|unsorted|color|height|width|bind|thread|erase|modeless|scroll|system|menu|title-bar|wrap|destroy|resizeable|user-gray|large-font|newline|3-d|data-columns|display-columns|alignment|separation|cursor-frame-width|divider-color|drag-color|heading-color|heading-divider-color|num-rows|record-data|tiled-headings|vpadding|centered-headings|column-headings|self-act|cancel-button|vscroll|report-composer|clsid|primary-interface|active-x-control|default-interface|default-source|auto-minimize|auto-resize|resource|engraved|initial-state|frame|acuactivexcontrol|activex-res|grid|box|message|namespace|class-name|module|constructor|version|strong|culture|method|handle|exception-value|read-only|dividers|graphical|indexed|termination-value|permanent|boxed|visible|centered)(?=\\s|\\.|,|;|$)",
+        "name": "keyword.cobol.acu strong"
+      },
+      {
+        "match": "(?<![-_])(?i:System-Info|Terminal-Info)(?=\\s|\\.|$)",
+        "name": "support.type.cobol.acu strong"
+      },
+      {
+        "begin": "(?i:remarks)",
+        "beginCaptures": {
+          "0": {
+            "name": "keyword.cobol"
+          }
+        },
+        "name": "comment.block.cobol.remark",
+        "end": "(?i:end\\-remark|\\*{Bench}end|environment\\s+division|data\\s+division|working-storage\\s+section)",
+        "endCaptures": {
+          "0": {
+            "name": "keyword.cobol"
+          }
+        }
+      },
+      {
+        "match": "(?<![-_])(?i:alter)(?=\\s|\\.)",
+        "name": "invalid.illegal.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:apply|areas|area|clock-units|code|com-reg|controls|dbcs|destination|detail|display-1|ending|every|insert|kanjikey|last|left|less|limits|limit|memory|metaclass|modules|more-labels|multiple|native_binary|native|negative|number|numeric-edited|other|padding|password|pf|ph|postive|processing|queue|recording|reload|removal|rerun|reserve|reserved|rewind|security|segment-limit|segment|separate|sequence|skip1|skip2|skip3|standard-1|standard-2|sub-queue-1|sub-queue-2|sub-queue-3|sum|symbolic|synchronized|sync|table|test|text|than|top|trace|trailing|unit|words|write-only|at|basis|beginning|bottom|cbl|cf|ch|de|positive|egcs|egi|emi|end|reversed|rf|rh|run|same|order|heading|esi)(?=\\s|\\.)",
+        "name": "keyword.ibmreserved.cobol strong"
+      },
+      {
+        "match": "(?i:filler)",
+        "name": "keyword.filler.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:date|day-of-week|day|debug-content|debug-item|debug-line|debug-item|debug-sub-1|debug-sub-2|debug-sub-3|shift-in|shift-out|sort-control|sort-core-size|sort-file-size|sort-message|sort-return|sort-mode-size|sort-return|tally|time|when-compiled|line-counter|page-counter|return-code|linage-counter|debug-line|debug-name|debug-contents)(?=\\s+|\\.|$)",
+        "name": "variable.language"
+      },
+      {
+        "match": "(?<![-_])(?i:self)",
+        "name": "keyword.other.self.cobol"
+      },
+      {
+        "match": "(?<![-_])(?i:super)",
+        "name": "keyword.other.super.cobol"
+      },
+      {
+        "match": "(^[0-9][0-9][0-9][0-9][0-9][0-9])",
+        "name": "constant.numeric.integer"
+      },
+      {
+        "match": "(?i:acquire|alias|background-colour|beep|commitment|control-area|db-format-name|dbcs-edited|default|described|drop|ebcdic|empty-check|externally-described-key|file-stream|foreground-colour|indic|indicator|indicators|kanji|left-justify|length-check|library|locale|modified|null-key-map|null-map|prior|process|right-justify|rolling|secure|space-fill|starting|subfile|trailing-sign|transaction|vlr|zero-fill|years|months|days|hours|minutes|seconds|microseconds|picoseconds)(?=\\s|\\.)",
+        "name": "keyword.identifiers.cobol.ibmi"
+      },
+      {
+        "match": "([0-9a-zA-Z][a-zA-Z\\-0-9]+)",
+        "name": "meta.symbol.cobol"
+      }
+    ],
+    "scopeName": "source.cobol"
+  }
+  


### PR DESCRIPTION
One IBM i language that is not covered is the COBOL language, this PR contributes COBOL language id, language configuration, and TextMate grammar. 