### PR TITLE
Fix invalid regex in RPGLE grammar

### DIFF
--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -785,7 +785,7 @@
 						"2": { "name": "keyword.control.rpgle.fixed.precompiler.conditional" },
 						"3": { "name": "keyword.other.rpgle.fixed.precompiler.defcheck" }
 					},
-					"end": "(?i)(?=^.{5})(H|F|D|I|C|O|P|\\s)(\\/ENDIF))",
+					"end": "(?i)(?=^.{5})(H|F|D|I|C|O|P|\\s)(\\/ENDIF)",
 					"endCaptures": {
 						"1": { "name": "keyword.other.rpgle.fixed.precompiler.conditional" },
 						"2": { "name": "keyword.control.rpgle.fixed.precompiler.conditional" }


### PR DESCRIPTION
https://github.com/barrettotte/vscode-ibmi-languages/pull/127 introduced an error in one of the regular expressions which we've picked up in the [GitHub Linguist](https://github.com/github-linguist/linguist) grammar compiler:

Invalid regex in grammar: `source.rpgle` (in `syntaxes/rpgle.tmLanguage.json`) contains a malformed regex (regex "`(?i)(?=^.{5})(H|F|D|I|C|O|P|\s)(`...": unmatched parentheses (at offset 40))

This PR fixes that by removing the extra closing bracket.

/cc @chrjorgensen as the original author of https://github.com/barrettotte/vscode-ibmi-languages/pull/127