### PR TITLE
Fix variants in identifiers

### DIFF
--- a/syntaxes/cl.tmLanguage.json
+++ b/syntaxes/cl.tmLanguage.json
@@ -55,7 +55,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.cl.label",
-                    "match": "^\\s*[a-zA-Z_@#$][a-zA-Z0-9_@#$]*:"
+                    "match": "^\\s*[a-zA-Z_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ]*:"
                 },
                 {
                     "name": "keyword.other.cl",
@@ -185,7 +185,7 @@
             "patterns": [
                 {
                     "name": "variable.parameter.cl",
-                    "match": "[&][a-zA-Z_@#$][a-zA-Z0-9_@#$]*"
+                    "match": "[&][a-zA-Z_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ]*"
                 }
             ]
         }

--- a/syntaxes/cmd.tmLanguage.json
+++ b/syntaxes/cmd.tmLanguage.json
@@ -51,7 +51,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.cmd.label",
-                    "match": "^\\s*[a-zA-Z_][a-zA-Z0-9_]*:"
+                    "match": "^\\s*[a-zA-Z_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ]*:"
                 },
                 {
                     "name": "keyword.other.cmd",
@@ -99,7 +99,7 @@
             "patterns": [
                 {
                     "name": "variable.parameter.cmd",
-                    "match": "[&][a-zA-Z_][a-zA-Z0-9_]*"
+                    "match": "[&][a-zA-Z_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_@#$§ÆØÅÄÖ£Ñ¥àÐŞİ]*"
                 }
             ]
         }

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -114,15 +114,15 @@
 				},
 				{
 					"name": "support.function.rpgle.sql",
-					"match": "[a-zA-Z_#@$][a-zA-Z0-9_#@$]*(?=\\()"
+					"match": "[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*(?=\\()"
 				},
 				{
 					"name": "constant.language.rpgle.sql.schema",
-					"match": "[a-zA-Z_#@$][a-zA-Z0-9_#@$]*(\\.|\\/)[a-zA-Z_#@$][a-zA-Z0-9_#@$]*"
+					"match": "[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*(\\.|\\/)[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*"
 				},
 				{
 					"name": "variable.parameter.rpgle.sql",
-					"match": "[:][a-zA-Z_#@$][a-zA-Z0-9_#@$\\.]*"
+					"match": "[:][a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ\\.]*"
 				},
 				{
 					"name": "keyword.operator.rpgle.sql.reserved",
@@ -160,7 +160,7 @@
 			"patterns": [
 				{
 					"name": "variable.other.rpgle.free.definition.identifier",
-					"begin": "[a-zA-Z_#@$][a-zA-Z0-9_#@$]*",
+					"begin": "[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*",
 					"end": "(?=\n)",
 					"patterns": [
 						{
@@ -600,7 +600,7 @@
 								},
 								{
 									"name": "variable.other",
-									"match": "((?i)[a-zA-Z_#@$][a-zA-Z0-9_#@$]*)|\\(|\\)|\\%"
+									"match": "((?i)[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*)|\\(|\\)|\\%"
 								}
 							]
 						},

--- a/tests/issues/136.clle
+++ b/tests/issues/136.clle
@@ -1,0 +1,68 @@
+pgm
+
+dcl &@te@st@ *char 1
+dcl &#te#st# *char 1
+dcl &$te$st$ *char 1
+
+/* note: double click doesn't select full identifier */
+/*   but, single clicking highlights full identifier */
+/* I guess that's the correct behavior?              */
+
+/* Additional variants: https://docs.google.com/spreadsheets/d/1J4yEGkfhtmACfdDVyD2XNJe0jjrIK77Um6-wsvW0etM/edit?usp=sharing */
+
+/* CCSID 273 (Austria and Germany) */
+dcl &@te@st@ *char 1
+dcl &§te§st§ *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 277 (Denmark and Norway) */
+dcl &ØteØstØ *char 1
+dcl &ÆteÆstÆ *char 1
+dcl &ÅteÅstÅ *char 1
+
+/* CCSID 278 (Finland and Sweden) */
+dcl &ÖteÖstÖ *char 1
+dcl &ÄteÄstÄ *char 1
+dcl &ÅteÅstÅ *char 1
+
+/* CCSID 280 (Italy) */
+dcl &§te§st§ *char 1
+dcl &£te£st£ *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 284 (Spain and Latin America) */
+dcl &@te@st@ *char 1
+dcl &ÑteÑstÑ *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 285 (Ireland and the United Kingdom) */
+dcl &@te@st@ *char 1
+dcl &#te#st# *char 1
+dcl &£te£st£ *char 1
+
+/* CCSID 290 (Japan (katakana)) */
+dcl &@te@st@ *char 1
+dcl &#te#st# *char 1
+dcl &¥te¥st¥ *char 1
+
+/* CCSID 297 (France) */
+dcl &àteàstà *char 1
+dcl &£te£st£ *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 423 (Greece) */
+dcl &§te§st§ *char 1
+dcl &£te£st£ *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 871 (Iceland) */
+dcl &ÐteÐstÐ *char 1
+dcl &#te#st# *char 1
+dcl &$te$st$ *char 1
+
+/* CCSID 905 (Turkey - Latin-3) */
+dcl &ŞteŞstŞ *char 1
+dcl &ÖteÖstÖ *char 1
+dcl &İteİstİ *char 1
+
+endpgm

--- a/tests/issues/136.cmd
+++ b/tests/issues/136.cmd
@@ -1,0 +1,114 @@
+cmd             prompt( 'Variant characters in identifiers' )
+
+parm            &@te@st@     *char      1
+parm            &#te#st#     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qual@#$        prompt( 'Object' )
+qual@#$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* note: double click doesn't select full identifier */
+/*   but, single clicking highlights full identifier */
+/* I guess that's the correct behavior?              */
+
+/* Additional variants: https://docs.google.com/spreadsheets/d/1J4yEGkfhtmACfdDVyD2XNJe0jjrIK77Um6-wsvW0etM/edit?usp=sharing */
+
+/* CCSID 273 (Austria and Germany) */
+parm            &@te@st@     *char      1
+parm            &#te#st#     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qual@#$        prompt( 'Object' )
+qual@#$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 277 (Denmark and Norway) */
+parm            &ØteØstØ     *char      1
+parm            &ÆteÆstÆ     *char      1
+parm            &ÅteÅstÅ     *char      1
+
+parm            &qualified   qualØÆÅ        prompt( 'Object' )
+qualØÆÅ:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 278 (Finland and Sweden) */
+parm            &ÖteÖstÖ     *char      1
+parm            &ÄteÄstÄ     *char      1
+parm            &ÅteÅstÅ     *char      1
+
+parm            &qualified   qualÖÄÅ        prompt( 'Object' )
+qualÖÄÅ:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 280 (Italy) */
+parm            &§te§st§     *char      1
+parm            &£te£st£     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qual§£$        prompt( 'Object' )
+qual§£$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 284 (Spain and Latin America) */
+parm            &@te@st@     *char      1
+parm            &ÑteÑstÑ     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qual@Ñ$        prompt( 'Object' )
+qual@Ñ$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 285 (Ireland and the United Kingdom) */
+parm            &@te@st@     *char      1
+parm            &#te#st#     *char      1
+parm            &£te£st£     *char      1
+
+parm            &qualified   qual@#£        prompt( 'Object' )
+qual@#£:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 290 (Japan (katakana)) */
+parm            &@te@st@     *char      1
+parm            &#te#st#     *char      1
+parm            &¥te¥st¥     *char      1
+
+parm            &qualified   qual@#¥        prompt( 'Object' )
+qual@#¥:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 297 (France) */
+parm            &àteàstà     *char      1
+parm            &£te£st£     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qualà£$        prompt( 'Object' )
+qualà£$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 423 (Greece) */
+parm            &§te§st§     *char      1
+parm            &£te£st£     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qual§£$        prompt( 'Object' )
+qual§£$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 871 (Iceland) */
+parm            &ÐteÐstÐ     *char      1
+parm            &#te#st#     *char      1
+parm            &$te$st$     *char      1
+
+parm            &qualified   qualÐ#$        prompt( 'Object' )
+qualÐ#$:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )
+
+/* CCSID 905 (Turkey - Latin-3) */
+parm            &ŞteŞstŞ     *char      1
+parm            &ÖteÖstÖ     *char      1
+parm            &İteİstİ     *char      1
+
+parm            &qualified   qualŞÖİ        prompt( 'Object' )
+qualŞÖİ:        qual         *name     10
+                qual         *name     10   prompt( 'Library' )

--- a/tests/issues/136.rpgle
+++ b/tests/issues/136.rpgle
@@ -7,3 +7,60 @@ dcl-s $te$st$ char(16) inz(*blanks);
 // note: double click doesn't select full identifier
 //   but, single clicking highlights full identifier
 // I guess that's the correct behavior?
+
+// Additional variants: https://docs.google.com/spreadsheets/d/1J4yEGkfhtmACfdDVyD2XNJe0jjrIK77Um6-wsvW0etM/edit?usp=sharing
+
+// CCSID 273 (Austria and Germany)
+dcl-s @te@st@ char(16) inz(*blanks);
+dcl-s §te§st§ char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 277 (Denmark and Norway)
+dcl-s ØteØstØ char(16) inz(*blanks);
+dcl-s ÆteÆstÆ char(16) inz(*blanks);
+dcl-s ÅteÅstÅ char(16) inz(*blanks);
+
+// CCSID 278 (Finland and Sweden)
+dcl-s ÖteÖstÖ char(16) inz(*blanks);
+dcl-s ÄteÄstÄ char(16) inz(*blanks);
+dcl-s ÅteÅstÅ char(16) inz(*blanks);
+
+// CCSID 280 (Italy)
+dcl-s §te§st§ char(16) inz(*blanks);
+dcl-s £te£st£ char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 284 (Spain and Latin America)
+dcl-s @te@st@ char(16) inz(*blanks);
+dcl-s ÑteÑstÑ char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 285 (Ireland and the United Kingdom)
+dcl-s @te@st@ char(16) inz(*blanks);
+dcl-s #te#st# char(16) inz(*blanks);
+dcl-s £te£st£ char(16) inz(*blanks);
+
+// CCSID 290 (Japan (katakana))
+dcl-s @te@st@ char(16) inz(*blanks);
+dcl-s #te#st# char(16) inz(*blanks);
+dcl-s ¥te¥st¥ char(16) inz(*blanks);
+
+// CCSID 297 (France)
+dcl-s àteàstà char(16) inz(*blanks);
+dcl-s £te£st£ char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 423 (Greece)
+dcl-s §te§st§ char(16) inz(*blanks);
+dcl-s £te£st£ char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 871 (Iceland)
+dcl-s ÐteÐstÐ char(16) inz(*blanks);
+dcl-s #te#st# char(16) inz(*blanks);
+dcl-s $te$st$ char(16) inz(*blanks);
+
+// CCSID 905 (Turkey - Latin-3)
+dcl-s ŞteŞstŞ char(16) inz(*blanks);
+dcl-s ÖteÖstÖ char(16) inz(*blanks);
+dcl-s İteİstİ char(16) inz(*blanks);


### PR DESCRIPTION
This PR will
- add variants of $, @ and # in other CCSID's to the RPGLE identifier regexes
![image](https://github.com/barrettotte/vscode-ibmi-languages/assets/13275072/37cc7194-3a94-4181-8c8c-6cdc1fc427a1)

- add $, @ and # and variants in other CCSID's to the CLLE identifier regexes
![image](https://github.com/barrettotte/vscode-ibmi-languages/assets/13275072/f73962ee-4ef4-4c0a-a81d-026963b9a2bc)

- add $, @ and # and variants in other CCSID's to the CMD identifier regexes
![image](https://github.com/barrettotte/vscode-ibmi-languages/assets/13275072/25b023b0-8e14-4f4d-b17d-1aa4259fb595)
