### PR TITLE
Add RPT to RPG syntaxes for RPT support

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,12 +137,14 @@
                     "RPG",
                     "SQLRPG",
                     "RPG/400",
-                    "RPG38"
+                    "RPG38",
+                    "RPT"
                 ],
                 "extensions": [
                     ".rpg",
                     ".rpg38",
-                    ".sqlrpg"
+                    ".sqlrpg",
+                    ".rpt"
                 ],
                 "configuration": "./configurations/rpg.language-configuration.json"
             },


### PR DESCRIPTION
In the organization where I work, we still have "RPT" source files that use the same syntax as "RPG". I took the liberty of including RPT in the languages so that it can be recognized and formatted.

Best regards, and thank you for the work you do. I'm a fan of your work :-)