### PR TITLE
Fix CL comment rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ibmi-languages",
     "displayName": "IBMi Languages",
     "description": "Syntax highlighting for IBM i languages such as RPG, CL, DDS, MI, and RPGLE fixed/free.",
-    "version": "0.6.21",
+    "version": "0.6.22",
     "publisher": "barrettotte",
     "author": {
         "name": "Barrett Otte"

--- a/syntaxes/cl.tmLanguage.json
+++ b/syntaxes/cl.tmLanguage.json
@@ -26,7 +26,7 @@
             "patterns": [
                 {
                     "name": "comment.line.cl",
-                    "begin": "(?i)(\\/\\*)(?!(ALL|FIRST))",
+                    "begin": "(^\\/\\*)|([ ]\\/\\*)|(\\/\\*[ \\*])",
                     "end": "(\\*\\/)"
                 }
             ]

--- a/tests/general/test-cl-comments.clle
+++ b/tests/general/test-cl-comments.clle
@@ -1,0 +1,28 @@
+pgm
+
+dcl &test *char 10
+/*Is this a comment? Yes*/dcl &varA *char 1
+ /*Is this a comment? Yes*/dcl &varB *char 1
+ /* Is this a comment? Yes*/dcl &varC *char 1
+ /**Is this a comment? Yes*/dcl &varD *char 1
+LABEL1:/*Is this a comment? NO, compile will fail!*/
+LABEL2: /*Is this a comment? Yes*/
+LABEL3:/**Is this a comment? Yes*/
+
+chgvar &test ( '/* Is this a comment? No, it is a string */' )
+
+chgvar &test/* Is this a comment? Yes */( 'text' )
+
+/*Is this a comment?*/chgvar &test 'a'
+ /*Is this a comment?*/chgvar &test 'a'
+chgvar/*Is this a comment? NO, compile will fail!*/&test 'a'
+chgvar /*Is this a comment? Yes*/&test 'a'
+chgvar /**Is this a comment? Yes*/&test 'a'
+chgvar /*Is this a comment? &test 'a' +
+Yes*/&test 'a'
+
+/* Is *ALL identified as special value and not start of comment? Yes*/
+dspobjd obj(&test/*ALL) objtype(*file) output(*outfile) outfile(qtemp/objects) +
+/* vscode comment fix */
+
+endpgm


### PR DESCRIPTION
This PR will fix the rules for CL comments according to the [CL Programming Guide](https://www.ibm.com/docs/en/i/7.5?topic=commands-writing-comments-in-cl-programs-procedures).

> Therefore, the starting comment delimiter can be entered in different ways. The starting comment delimiter, /*, can:
> 
>     Begin in the first position of the command string
>     Be preceded by a blank
>     Be followed by a blank
>     Be followed by an asterisk (/**)

This will ensure correct marking of comments, and any special values after a `/` will not be considered start of comment.