### PR TITLE
Fix inconsistent RPGLE declaration identifier and END keyword highlighting

### DIFF
--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -248,27 +248,6 @@
           ]
         },
         {
-          "name": "rpgle.free.definition.complex-single",
-          "begin": "(?i)(?=(\\b(DCL\\-)(PR|DS)\\b))",
-          "end": "\n",
-          "patterns": [
-            {
-              "name": "storage.type.rpgle.free.definition.complex-single.dcl",
-              "match": "(?i)\\b(DCL\\-)(PR|DS)\\b"
-            },
-            {
-              "name": "storage.type.rpgle.free.definition.complex-single.end",
-              "match": "(?i)\\b(END\\-)(PR|DS)\\b"
-            },
-            {
-              "include": "#freedefkeywords"
-            },
-            {
-              "include": "#rpglecommon"
-            }
-          ]
-        },
-        {
           "name": "rpgle.free.definition.complex",
           "begin": "(?i)(?=(\\b(DCL\\-)(DS|ENUM|PROC|PR|PI)\\b))",
           "end": "\n",
@@ -278,22 +257,23 @@
               "match": "(?i)\\b(DCL\\-)(DS|ENUM|PROC|PR|PI)\\b"
             },
             {
-              "name": "storage.type.rpgle.free.definition.complex.end",
+              "name": "storage.type.rpgle.free.definition.complex.dcl",
               "match": "(?i)\\b(END\\-)(DS|ENUM|PROC|PR|PI)\\b"
             },
             {
               "include": "#freedefkeywords"
             },
             {
-              "include": "#freeidentifiers"
+              "include": "#rpglecommon"
             },
             {
-              "include": "#rpglecommon"
+              "name": "variable.other.rpgle.free.definition.identifier",
+              "match": "\\b[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*\\b"
             }
           ]
         },
         {
-          "name": "storage.type.rpgle.free.definition.complex.end",
+          "name": "storage.type.rpgle.free.definition.complex.dcl",
           "match": "(?i)\\b(END\\-)(DS|ENUM|PROC|PR|PI)\\b"
         },
         {

--- a/tests/issues/146.rpgle
+++ b/tests/issues/146.rpgle
@@ -1,0 +1,102 @@
+**free
+
+dcl-s myvar1 char(1);
+
+dcl-ds pgm_stat psds;
+  status *status;
+  routine *routine;
+  library char(10) pos(81);
+end-ds;
+
+dcl-ds myds1 qualified;
+  mysubf1 char(1);
+  mysubf2 varchar(30);
+  mysubf3 int(10);
+end-ds;
+
+dcl-ds myds2 likeds(myds1);
+
+dcl-ds person qualified;
+  name varchar(25);
+  dcl-ds address;
+    num int(5);
+    street varchar(25);
+    city varchar(25);
+    province varchar(25);
+    postcode varchar(6);
+  end-ds address;
+  age int(5);
+end-ds person;
+
+dcl-ds family qualified;
+  num int(5);
+  dcl-ds person dim(10);
+    name varchar(25);
+    age int(5);
+    numpets int(5);
+    dcl-ds pets dim(5);
+      name varchar(25);
+      type varchar(25);
+    end-ds pets;
+  end-ds person;
+end-ds;
+
+dcl-pr myproc1 int(5);
+  myparam1 likeds(myds) options(*exact) const;
+end-pr;
+
+dcl-pr myproc3 int(5) end-pr;
+
+dcl-pr mypgm1 extpgm;
+  name char(10) options(*exact)const;
+end-pr;
+
+dcl-s colour_t varchar(11) template;
+
+dcl-proc myproc1;
+  dcl-pi myproc1 int(5);
+    myparam1 likeds(myds) options(*exact) const;
+  end-pi;
+
+  dcl-s myvar2 int(5);
+  dcl-c STATUS_NEW const('N');
+  dcl-c STATUS_COMPLETE const('C');
+
+  if myds1.mysubf1 = STATUS_NEW;
+    myvar2 = 10;
+  elseif myds1.mysubf1 = STATUS_COMPLETE;
+    myvar2 = 90;
+  else;
+    myvar2 = 0;
+  endif;
+
+  return myvar2;
+end-proc;
+
+dcl-proc myproc2;
+  dcl-pi *n int(5);
+    myparam1 likeds(myds) options(*exact) const;
+  end-pi;
+
+  dcl-ds extds1 extname('QIWS/QCUSTCDT');
+
+  dcl-s myvar3 int(5);
+
+  return myvar3;
+end-proc;
+
+dcl-proc myproc3;
+  dcl-pi *n like(colour_t) end-pi;
+
+  dcl-s myvar3 like(colour_t);
+
+  dcl-enum colours qualified;
+    green '0,255,0';
+    red '255,0,0';
+    blue '0,0,255';
+  end-enum;
+
+  myvar3 = colours.green;
+
+  return myvar3;
+end-proc;


### PR DESCRIPTION
This patch addresses issue #146.

## Summary of Changes

RPGLE free-format declaration identifiers were being highlighted inconsistently:
1. Identifiers after `DCL-DS`/`DCL-PR` had different colours than identifiers after `DCL-PROC`/`DCL-PI`.
1. On single-line declarations like `dcl-pr myproc2 end-pr;`, the `end-pr` keyword was not recognised (treated as separate tokens `end` + `pr`).

## Root Causes

1. **Redundant pattern**: Two overlapping patterns (`complex-single` and `complex`) matched the same keywords but assigned different scopes.
1. **Missing identifier highlighting**: The `complex-single` pattern didn't include `#freeidentifiers`.
1. **Greedy identifier pattern**: The `#freeidentifiers` pattern used `begin`/`end` and captured until newline, preventing `END-PR` keywords from being matched.

## Changes Made to `syntaxes/rpgle.tmLanguage.json`

**Change 1**: Removed redundant `complex-single` pattern (lines 250-270, ~21 lines removed)
* Removed the pattern that matched single-line `DCL-DS` and `DCL-PR` declarations
* The complex pattern now handles all complex declarations (both single-line and multi-line)

It's highly unlikely that this scope has been referenced externally in colour themes, user settings or other extensions so I believe it is safe to remove it.

**Change 2**: Unified `END` keyword scopes (2 locations)
* Line 260: Changed `END-*` scope from `storage.type.rpgle.free.definition.complex.end` to `storage.type.rpgle.free.definition.complex.dcl`
* Line 276: Changed standalone `END-*` pattern scope from `.end` to `.dcl`
* Result: `DCL-*` and `END-*` keywords now use the same scope, so themes colour them consistently

Originally, the grammar assigned different scopes to the start and end keywords:
* `DCL-DS` → `storage.type.rpgle.free.definition.complex.dcl`
* `END-DS` → `storage.type.rpgle.free.definition.complex.end`

This meant colour themes could apply different colours to these keywords.

* `DCL` is the primary keyword - The declaration starts with `DCL-*`, so that's the "main" scope
* `END` is part of the declaration syntax - It's not a separate concept, it's the closing of the declaration

**Change 3**: Replaced greedy `#freeidentifiers` with simple match (lines 266-271)
* Removed: `{"include": "#freeidentifiers"}` (greedy pattern that captured until newline)
* Added: Direct match pattern for identifiers: `"match": "\\b[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*\\b"`
* Reordered: Moved identifier matching to last position (after `#rpglecommon`)
* Result: Identifiers are highlighted, but `END-PR` keywords can still be recognised on the same line

When removing the `complex-single` pattern, I consolidated everything into the `complex` pattern. But the `complex` pattern included `#freeidentifiers`.
* `#freeidentifiers` is a begin/end pattern.
* Once it matches an identifier like `myproc2`, it captures everything until the newline, including the `end-pr`.

This caused the following problem.

`dcl-pr myproc2 end-pr;`

Parsing flow with `#freeidentifiers`:
✅ `dcl-pr` matches → `storage.type.rpgle.free.definition.complex.dcl`
✅ `myproc2` matches `#freeidentifiers` begin
❌ `#freeidentifiers` captures until `\n`, so `end-pr` is inside the identifier context
❌ `end-pr` gets treated as text/identifier parts, not as a keyword

I saw this in the token inspector - it showed `end` and `pr` as separate tokens, not as the `END-PR` keyword.

The solution was to replace `#freeidentifiers` with an inline pattern that matches one identifier at a time.

## Impact

1. All declaration identifiers (`DCL-S`, `DCL-DS`, `DCL-PR`, `DCL-PROC`, `DCL-PI`) now get consistent highlighting
1. Declaration and end keywords (`DCL-*` / `END-*`) use matching colours
1. Single-line declarations like `dcl-pr myproc2 end-pr;` correctly recognise both keywords
1. No breaking changes - all existing code continues to work


## Testing

I have manually reviewed all of the RPG test files in the following themes to verify that not only do my change works but that this change hasn't broken any other logic.

* Modern Dark
* Modern Light (you can hardly notice the original problem)
* Solarized Dark
* Monokai Dimmed (the changes are most noticeable with this theme)

I also created a new test file `tests/issues/146.rpgle` that includes the specific definitions I wanted to test. 


### Before

<img width="494" height="438" alt="image" src="https://github.com/user-attachments/assets/ca5eb2da-dd6d-4397-95ed-24ffc060d59f" />

### After

<img width="482" height="441" alt="image" src="https://github.com/user-attachments/assets/00847769-3abc-4347-8ba6-03384ad40f61" />




