### PR TITLE
Fix: RPGLE syntax highlighting breaks on string/SQL tokens in fixed-f…

### DIFF
--- a/syntaxes/dds.dspf.tmLanguage.json
+++ b/syntaxes/dds.dspf.tmLanguage.json
@@ -1,183 +1,196 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "DDS.DSPF",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#gutter"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.dds.dspf",
-					"match": "^.{5}(.)(\\*).*"
-				}
-			]
-		},
-		"gutter": {
-			"patterns": [
-				{
-					"name": "comment.gutter",
-					"match": "^.{5}"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-                    "name": "constant.language.dds.dspf",
-                    "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
-                },
-				{
-					"name": "constant.language.dds.dspf.andor",
-					"match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
-                },
-                {
-                    "name": "constant.language.dds.dspf.n01",
-					"match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.n02",
-					"match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.n03",
-					"match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.nameType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{10})(R|H)"
-                },
-                {
-                    "name": "constant.language.dds.dspf.ref",
-					"match": "(?i)(?<=^.{5}(A|\\s).{22})(R)"
-                },
-                {
-                    "name": "constant.language.dds.dspf.len",
-					"match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.dataType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{28})(A|D|E|F|G|I|J|L|M|N|O|S|T|W|X|Y|Z)"
-                },
-                {
-                    "name": "constant.language.dds.dspf.decpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.usage",
-					"match": "(?i)(?<=^.{5}(A|\\s).{31})(O|I|B|H|M|P)"
-                },
-                {
-                    "name": "constant.language.dds.dspf.locline",
-					"match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s){3}"
-                },
-                {
-                    "name": "constant.language.dds.dspf.locpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{35})([0-9]|\\s){3}"
-                },
-                {
-                    "name": "constant.numeric.dds.dspf",
-                    "match": "\\b([0-9]+)\\b"
-				},
-				{
-					"name": "dds.dspf.check",
-					"begin": "(?i)(?<=(CHECK\\())",
-					"end": "(?=(\\)))",
-					"patterns": [
-						{
-							"name": "constant.other.dds.dspf.check.values",
-							"match": "(?i)(\\b(AB|ME|MF|M10F|M10|M11F|M11|VNE|VN|ER|FE|LC|RB|RZ|RLTB|RL)\\b)"
-						}
-					]
-				},
-				{
-					"name": "dds.dspf.dspatr",
-					"begin": "(?i)(?<=(DSPATR\\())",
-					"end": "(?=(\\)))",
-					"patterns": [
-						{
-							"name": "constant.other.dds.dspf.dspatr.values",
-							"match": "(?i)(\\b(SP|PR|OID|MDT|UL|RI|PC|ND|HI|CS|BL)\\b)"
-						}
-					]
-				},
-				{
-					"name": "dds.dspf.color",
-					"begin": "(?i)(?<=(COLOR\\())",
-					"end": "(?=(\\)))",
-					"patterns": [
-						{
-							"name": "constant.other.dds.dspf.color.values",
-							"match": "(?i)(\\b(BLU|PNK|YLW|TRQ|RED|WHT|GRN)\\b)"
-						}
-					]
-				},
-				{
-					"name": "dds.dspf.comp",
-					"begin": "(?i)((?<=((COMP)\\())|(?<=((CMP)\\()))",
-					"end": "(?=(\\)))",
-					"patterns": [
-						{
-							"name": "keyword.other.dds.dspf.comp.values",
-							"match": "(?i)(\\b(GE|LE|NG|GT|NL|LT|NE|EQ)\\b)"
-						},
-						{
-							"name": "constant.numeric.dds.dspf",
-							"match": "\\b([0-9]+)\\b"
-						}
-					]
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.other.dds.dspf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				},
-				{
-					"name": "keyword.other.dds.dspf",
-					"match": "\\+"
-				},
-                {
-                    "name": "keyword.other.dds.dspf.func",
-                    "match": "((?i)(C(A|F)))[0-9]{2}"
-                },
-				{
-					"name": "keyword.other.dds.dspf.funcs",
-					"match": "(?i)(?<=(.{44}))(WRDWRAP|WINDOW|WDWTITLE|WDWBORDER|VLDCMDKEY|VALUES|VALNUM|USRRSTDSP|USRDSPMGT|USRDFN|USER|UNLOCK|TIMSEP|TIMFMT|TIME|TEXT|SYSNAME|SNGCHCFLD|SLNO|SFLSNGCHC|SFLSIZ|SFLSCROLL|SFLRTNSEL|SFLROLVAL|SFLRNA|SFLRCDNBR|SFLPGMQ|SFLPAG|SFLNXTCHG|SFLMSGRCD|SFLMSGKEY|SFLMSG|SFLMODE|SFLMLTCHC|SFLLIN|SFLINZ|SFLFOLD|SFLENTER|SFLEND|SFLDSPCTL|SFLDSP|SFLDROP|SFLDLT|SFLCTL|SFLCSRRRN|SFLCSRPRG|SFLCLR|SFLCHCCTL|SETOFF|SETOF|RTNDTA|RTNCSRLOC|ROLLUP|ROLLDOWN|RMVWDW|RETLCKSTS|RETKEY|REFFLD|REF|RANGE|PUTRETAIN|PUTOVR|PULLDOWN|PSHBTNFLD|PSHBTNCHC|PROTECT|PRINT|PASSRCD|PAGEDOWN|PAGEUP|OVRDTA|OVRATR|OVERLAY|OPENPRT|NOCCSID|MSGLOC|MSGID|MSGCON|MSGALARM|MOUBTN|MNUCNL|MNUBARSW|MNUBARSEP|MNUBARDSP|MNUBARCHC|MNUBAR|MLTCHCFLD|MDTOFF|MAPVAL|LOWER|LOGOUT|LOGINP|LOCK|KEEP|INZRCD|INZINP|INVITE|INDTXT|INDARA|HTML|HOME|HLPTITLE|HLPSEQ|HLPSCHIDX|HLPRTN|HLPRCD|HLPPNLGRP|HLPID|HLPFULL|HLPEXCLD|HLPDOC|HLPCMDKEY|HLPCLR|HLPBDY|HLPARA|HELP|GETRETAIN|FRCDTA|FLTPCN|FLTFIXDEC|FLDCSRPRG|ERRSFL|ERRMSG|ERRMSGID|ERASEINP|ERASE|ENTFLDATR|EDTWRD|EDTMSK|EDTCDE|DUP|DSPSIZ|DSPRL|DSPMOD|DSPATR|DLTEDT|DLTCHK|DFTVAL|DFT|DATSEP|DATFMT|DATE|CSRLOC|CSRINPONLY|COMP|COLOR|CNTFLD|CLEAR|CHRID|CHOICE|CHKMSGID|CHGINPDFT|CHECK|CHCUNAVAIL|CHCSLT|CHCCTL|CHCAVAIL|CHCACCEL|CHANGE|BLKFOLD|BLINK|BLANKS|AUTO|ASSUME|ALWROL|ALWGPH|ALTPAGEDWN|ALTPAGEUP|ALTNAME|ALTHELP|ALIAS|ALARM)\\b"
-                },
-                {
-                    "name": "keyword.other.dds.dspf.funcs",
-                    "match": "\\b(?i)(CMP|CLRL|SFL)\\b"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.single.dds.dspf",
-			"begin": "'",
-			"end": "'",
-			"patterns": [
-				{
-					"name": "keyword.other.dds.dspf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				}
-			]
-		}
-	},
-	"scopeName": "source.dds.dspf"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DDS.DSPF",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#gutter"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.dds.dspf",
+          "match": "^.{5}(.)(\\*).*"
+        }
+      ]
+    },
+    "gutter": {
+      "patterns": [
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "comment.block.line.dds",
+          "begin": "(?<=^.{80})",
+          "end": "\n"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.dds.dspf",
+          "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
+        },
+        {
+          "name": "constant.language.dds.dspf.andor",
+          "match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
+        },
+        {
+          "name": "constant.language.dds.dspf.n01",
+          "match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.dspf.n02",
+          "match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.dspf.n03",
+          "match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.dspf.nameType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{10})(R|H)"
+        },
+        {
+          "name": "constant.language.dds.dspf.ref",
+          "match": "(?i)(?<=^.{5}(A|\\s).{22})(R)"
+        },
+        {
+          "name": "constant.language.dds.dspf.len",
+          "match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
+        },
+        {
+          "name": "constant.language.dds.dspf.dataType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{28})(A|D|E|F|G|I|J|L|M|N|O|S|T|W|X|Y|Z)"
+        },
+        {
+          "name": "constant.language.dds.dspf.decpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
+        },
+        {
+          "name": "constant.language.dds.dspf.usage",
+          "match": "(?i)(?<=^.{5}(A|\\s).{31})(O|I|B|H|M|P)"
+        },
+        {
+          "name": "constant.language.dds.dspf.locline",
+          "match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s){3}"
+        },
+        {
+          "name": "constant.language.dds.dspf.locpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{35})([0-9]|\\s){3}"
+        },
+        {
+          "name": "constant.numeric.dds.dspf",
+          "match": "\\b([0-9]+)\\b"
+        },
+        {
+          "name": "dds.dspf.check",
+          "begin": "(?i)(?<=(CHECK\\())",
+          "end": "(?=(\\)))",
+          "patterns": [
+            {
+              "name": "constant.other.dds.dspf.check.values",
+              "match": "(?i)(\\b(AB|ME|MF|M10F|M10|M11F|M11|VNE|VN|ER|FE|LC|RB|RZ|RLTB|RL)\\b)"
+            }
+          ]
+        },
+        {
+          "name": "dds.dspf.dspatr",
+          "begin": "(?i)(?<=(DSPATR\\())",
+          "end": "(?=(\\)))",
+          "patterns": [
+            {
+              "name": "constant.other.dds.dspf.dspatr.values",
+              "match": "(?i)(\\b(SP|PR|OID|MDT|UL|RI|PC|ND|HI|CS|BL)\\b)"
+            }
+          ]
+        },
+        {
+          "name": "dds.dspf.color",
+          "begin": "(?i)(?<=(COLOR\\())",
+          "end": "(?=(\\)))",
+          "patterns": [
+            {
+              "name": "constant.other.dds.dspf.color.values",
+              "match": "(?i)(\\b(BLU|PNK|YLW|TRQ|RED|WHT|GRN)\\b)"
+            }
+          ]
+        },
+        {
+          "name": "dds.dspf.comp",
+          "begin": "(?i)((?<=((COMP)\\())|(?<=((CMP)\\()))",
+          "end": "(?=(\\)))",
+          "patterns": [
+            {
+              "name": "keyword.other.dds.dspf.comp.values",
+              "match": "(?i)(\\b(GE|LE|NG|GT|NL|LT|NE|EQ)\\b)"
+            },
+            {
+              "name": "constant.numeric.dds.dspf",
+              "match": "\\b([0-9]+)\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.other.dds.dspf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        },
+        {
+          "name": "keyword.other.dds.dspf",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.other.dds.dspf.func",
+          "match": "((?i)(C(A|F)))[0-9]{2}"
+        },
+        {
+          "name": "keyword.other.dds.dspf.funcs",
+          "match": "(?i)(?<=(.{44}))(WRDWRAP|WINDOW|WDWTITLE|WDWBORDER|VLDCMDKEY|VALUES|VALNUM|USRRSTDSP|USRDSPMGT|USRDFN|USER|UNLOCK|TIMSEP|TIMFMT|TIME|TEXT|SYSNAME|SNGCHCFLD|SLNO|SFLSNGCHC|SFLSIZ|SFLSCROLL|SFLRTNSEL|SFLROLVAL|SFLRNA|SFLRCDNBR|SFLPGMQ|SFLPAG|SFLNXTCHG|SFLMSGRCD|SFLMSGKEY|SFLMSG|SFLMODE|SFLMLTCHC|SFLLIN|SFLINZ|SFLFOLD|SFLENTER|SFLEND|SFLDSPCTL|SFLDSP|SFLDROP|SFLDLT|SFLCTL|SFLCSRRRN|SFLCSRPRG|SFLCLR|SFLCHCCTL|SETOFF|SETOF|RTNDTA|RTNCSRLOC|ROLLUP|ROLLDOWN|RMVWDW|RETLCKSTS|RETKEY|REFFLD|REF|RANGE|PUTRETAIN|PUTOVR|PULLDOWN|PSHBTNFLD|PSHBTNCHC|PROTECT|PRINT|PASSRCD|PAGEDOWN|PAGEUP|OVRDTA|OVRATR|OVERLAY|OPENPRT|NOCCSID|MSGLOC|MSGID|MSGCON|MSGALARM|MOUBTN|MNUCNL|MNUBARSW|MNUBARSEP|MNUBARDSP|MNUBARCHC|MNUBAR|MLTCHCFLD|MDTOFF|MAPVAL|LOWER|LOGOUT|LOGINP|LOCK|KEEP|INZRCD|INZINP|INVITE|INDTXT|INDARA|HTML|HOME|HLPTITLE|HLPSEQ|HLPSCHIDX|HLPRTN|HLPRCD|HLPPNLGRP|HLPID|HLPFULL|HLPEXCLD|HLPDOC|HLPCMDKEY|HLPCLR|HLPBDY|HLPARA|HELP|GETRETAIN|FRCDTA|FLTPCN|FLTFIXDEC|FLDCSRPRG|ERRSFL|ERRMSG|ERRMSGID|ERASEINP|ERASE|ENTFLDATR|EDTWRD|EDTMSK|EDTCDE|DUP|DSPSIZ|DSPRL|DSPMOD|DSPATR|DLTEDT|DLTCHK|DFTVAL|DFT|DATSEP|DATFMT|DATE|CSRLOC|CSRINPONLY|COMP|COLOR|CNTFLD|CLEAR|CHRID|CHOICE|CHKMSGID|CHGINPDFT|CHECK|CHCUNAVAIL|CHCSLT|CHCCTL|CHCAVAIL|CHCACCEL|CHANGE|BLKFOLD|BLINK|BLANKS|AUTO|ASSUME|ALWROL|ALWGPH|ALTPAGEDWN|ALTPAGEUP|ALTNAME|ALTHELP|ALIAS|ALARM)\\b"
+        },
+        {
+          "name": "keyword.other.dds.dspf.funcs",
+          "match": "\\b(?i)(CMP|CLRL|SFL)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.single.dds.dspf",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "comment.line.dds.dspf",
+          "match": "^.{5}(.)(\\*).*"
+        },
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "keyword.other.dds.dspf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.dds.dspf"
 }

--- a/syntaxes/dds.icff.tmLanguage.json
+++ b/syntaxes/dds.icff.tmLanguage.json
@@ -1,131 +1,144 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "DDS.ICFF",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#gutter"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.dds.icff",
-					"match": "^.{5}(.)(\\*).*"
-				}
-			]
-		},
-		"gutter": {
-			"patterns": [
-				{
-					"name": "comment.gutter",
-					"match": "^.{5}"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-                    "name": "constant.language.dds.icff",
-                    "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
-                },
-				{
-					"name": "constant.language.dds.icff.andor",
-					"match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
-                },
-                {
-                    "name": "constant.language.dds.icff.n01",
-					"match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.icff.n02",
-					"match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.icff.n03",
-					"match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
-                }, 
-                {
-                    "name": "constant.language.dds.icff.nameType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{10})(R|H)"
-                },
-                {
-                    "name": "constant.language.dds.icff.ref",
-					"match": "(?i)(?<=^.{5}(A|\\s).{22})(R)"
-                },
-                {
-                    "name": "constant.language.dds.icff.len",
-					"match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
-                },
-                {
-                    "name": "constant.language.dds.icff.dataType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|O)"
-                },
-                {
-                    "name": "constant.language.dds.icff.decpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
-                },
-                {
-                    "name": "constant.language.dds.icff.usage",
-					"match": "(?i)(?<=^.{5}(A|\\s).{31})(B|P)"
-                },
-                {
-                    "name": "constant.language.dds.icff.locline",
-					"match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s){3}"
-                },
-                {
-                    "name": "constant.numeric.dds.icff",
-                    "match": "\\b([0-9]+)\\b"
-                }
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.other.dds.icff.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				},
-				{
-					"name": "keyword.other.dds.icff",
-					"match": "\\+"
-				},
-                {
-                    "name": "keyword.other.dds.icff.func", 
-                    "match": "((?i)(C(A|F)))[0-9]{2}"
-                },
-				{
-					"name": "keyword.other.dds.icff.funcs",
-					"match": "(?i)(?<=(.{44}))(VARLEN|VARBUFMGT|TNSSYNLVL|TIMER|TEXT|SYNLVL|SUBDEV|SECURITY|RSPCONFIRM|RQSWRT|REFFLD|REF|RECID|RCVTRNDRND|RCVTKCMT|RCVROLLB|RCVNEGRSP|RCVFMH|RCVFAIL|RCVENDGRP|RCVDETACH|RCVCTLDTA|RCVCONFIRM|RCVCANCEL|PRPCMT|NEGRSP|INVITE|INDTXT|INDARA|FRCDTA|FMTNAME|FMH|FLTPCN|FAIL|EVOKE|EOS|ENDGRP|DFREVOKE|DETACH|CTLDTA|CONFIRM|CNLINVITE|CANCEL|ALWWRT|ALIAS)\\b"
-                },
-                {
-                    "name": "keyword.other.dds.icff.funcs",
-                    "match": "\\b(?i)(CMP|CLRL|SFL)\\b"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.single.dds.icff",
-			"begin": "'",
-			"end": "'",
-			"patterns": [
-				{
-					"name": "keyword.other.dds.icff.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				}
-			]
-		}
-	},
-	"scopeName": "source.dds.icff"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DDS.ICFF",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#gutter"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.dds.icff",
+          "match": "^.{5}(.)(\\*).*"
+        }
+      ]
+    },
+    "gutter": {
+      "patterns": [
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "comment.block.line.dds",
+          "begin": "(?<=^.{80})",
+          "end": "\n"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.dds.icff",
+          "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
+        },
+        {
+          "name": "constant.language.dds.icff.andor",
+          "match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
+        },
+        {
+          "name": "constant.language.dds.icff.n01",
+          "match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.icff.n02",
+          "match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.icff.n03",
+          "match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.icff.nameType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{10})(R|H)"
+        },
+        {
+          "name": "constant.language.dds.icff.ref",
+          "match": "(?i)(?<=^.{5}(A|\\s).{22})(R)"
+        },
+        {
+          "name": "constant.language.dds.icff.len",
+          "match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
+        },
+        {
+          "name": "constant.language.dds.icff.dataType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|O)"
+        },
+        {
+          "name": "constant.language.dds.icff.decpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
+        },
+        {
+          "name": "constant.language.dds.icff.usage",
+          "match": "(?i)(?<=^.{5}(A|\\s).{31})(B|P)"
+        },
+        {
+          "name": "constant.language.dds.icff.locline",
+          "match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s){3}"
+        },
+        {
+          "name": "constant.numeric.dds.icff",
+          "match": "\\b([0-9]+)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.other.dds.icff.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        },
+        {
+          "name": "keyword.other.dds.icff",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.other.dds.icff.func",
+          "match": "((?i)(C(A|F)))[0-9]{2}"
+        },
+        {
+          "name": "keyword.other.dds.icff.funcs",
+          "match": "(?i)(?<=(.{44}))(VARLEN|VARBUFMGT|TNSSYNLVL|TIMER|TEXT|SYNLVL|SUBDEV|SECURITY|RSPCONFIRM|RQSWRT|REFFLD|REF|RECID|RCVTRNDRND|RCVTKCMT|RCVROLLB|RCVNEGRSP|RCVFMH|RCVFAIL|RCVENDGRP|RCVDETACH|RCVCTLDTA|RCVCONFIRM|RCVCANCEL|PRPCMT|NEGRSP|INVITE|INDTXT|INDARA|FRCDTA|FMTNAME|FMH|FLTPCN|FAIL|EVOKE|EOS|ENDGRP|DFREVOKE|DETACH|CTLDTA|CONFIRM|CNLINVITE|CANCEL|ALWWRT|ALIAS)\\b"
+        },
+        {
+          "name": "keyword.other.dds.icff.funcs",
+          "match": "\\b(?i)(CMP|CLRL|SFL)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.single.dds.icff",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "comment.line.dds.icff",
+          "match": "^.{5}(.)(\\*).*"
+        },
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "keyword.other.dds.icff.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.dds.icff"
 }

--- a/syntaxes/dds.lf.tmLanguage.json
+++ b/syntaxes/dds.lf.tmLanguage.json
@@ -1,118 +1,131 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "DDS.LF",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#gutter"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.dds.lf",
-					"match": "^.{5}(.)(\\*).*"
-				}
-			]
-		},
-		"gutter": {
-			"patterns": [
-				{
-					"name": "comment.gutter",
-					"match": "^.{5}"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-                    "name": "constant.language.dds.lf",
-                    "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
-                },
-				{
-					"name": "constant.language.dds.lf.nametype",
-					"match": "(?i)(?<=^.{5}(A|\\s).{10})(R|K|J|S|O)"
-				},
-				{
-					"name": "constant.language.dds.lf.ref",
-					"match": "(?i)(?<=^.{5}(A|\\s).{22})R"
-				},
-				{
-					"name": "constant.language.dds.lf.len",
-					"match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
-				},
-				{
-					"name": "constant.language.dds.lf.datatype",
-					"match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|L|T|Z|H|J|E|O|G|5)"
-				},
-				{
-					"name": "constant.language.dds.lf.decpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
-				},
-				{
-					"name": "constant.language.dds.lf.use",
-					"match": "(?i)(?<=^.{5}(A|\\s).{31})(B|I|N)"
-				},
-                {
-                    "name": "constant.numeric.dds.lf",
-                    "match": "(\\b[0-9]+)|([0-9]*[.][0-9]*)"
-                }
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.other.dds.lf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				},
-				{
-					"name": "keyword.other.dds.lf",
-					"match": "\\+"
-				},
-				{
-					"name": "keyword.other.dds.lf.funcs",
-					"match": "(?i)(?<=(.{44}))(?<=((?<=^[\\s]{5}[A|\\s]).{38}))((ZONE|VARLEN|VALUES|UNSIGNED|UNIQUE|TIMSEP|TIMFMT|TEXT|SST|RENAME|REFSHIFT|REFACCPTH|RANGE|PFILE|NOALTSEQ|LIFO|JREF|JOIN|JFLD|JFILE|JDUPSEQ|JDFTVAL|FORMAT|FLTPCN|FIFO|FCFO|EDTCDE|EDTWRD|DYNSLT|DIGIT|DESCEND|DATSEP|DATFMT|CONCAT|COMP|COLHDG|CMP|CHKMSGID|CHECK|CCSID|ALTSEQ|ALL|ALIAS|ABSVAL)+)\\b"
-				},
-				{
-					"name": "dds.lf.comp",
-					"begin": "(?i)(?<=(.{44}))((?<=((COMP)\\())|(?<=((CMP)\\()))",
-					"end": "(?=(\\)))",
-					"patterns": [
-						{
-							"name": "keyword.other.dds.lf.comp.values",
-							"match": "(?i)(\\b(GE|LE|NG|GT|NL|LT|NE|EQ)\\b)"
-						},
-						{
-							"name": "constant.numeric.dds.lf",
-							"match": "\\b([0-9]+)\\b"
-						}
-					]
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.single.dds.lf",
-			"begin": "'",
-			"end": "'",
-			"patterns": [
-				{
-					"name": "keyword.other.dds.lf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				}
-			]
-		}
-	},
-	"scopeName": "source.dds.lf"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DDS.LF",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#gutter"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.dds.lf",
+          "match": "^.{5}(.)(\\*).*"
+        }
+      ]
+    },
+    "gutter": {
+      "patterns": [
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "comment.block.line.dds",
+          "begin": "(?<=^.{80})",
+          "end": "\n"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.dds.lf",
+          "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
+        },
+        {
+          "name": "constant.language.dds.lf.nametype",
+          "match": "(?i)(?<=^.{5}(A|\\s).{10})(R|K|J|S|O)"
+        },
+        {
+          "name": "constant.language.dds.lf.ref",
+          "match": "(?i)(?<=^.{5}(A|\\s).{22})R"
+        },
+        {
+          "name": "constant.language.dds.lf.len",
+          "match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
+        },
+        {
+          "name": "constant.language.dds.lf.datatype",
+          "match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|L|T|Z|H|J|E|O|G|5)"
+        },
+        {
+          "name": "constant.language.dds.lf.decpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
+        },
+        {
+          "name": "constant.language.dds.lf.use",
+          "match": "(?i)(?<=^.{5}(A|\\s).{31})(B|I|N)"
+        },
+        {
+          "name": "constant.numeric.dds.lf",
+          "match": "(\\b[0-9]+)|([0-9]*[.][0-9]*)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.other.dds.lf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        },
+        {
+          "name": "keyword.other.dds.lf",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.other.dds.lf.funcs",
+          "match": "(?i)(?<=(.{44}))(?<=((?<=^[\\s]{5}[A|\\s]).{38}))((ZONE|VARLEN|VALUES|UNSIGNED|UNIQUE|TIMSEP|TIMFMT|TEXT|SST|RENAME|REFSHIFT|REFACCPTH|RANGE|PFILE|NOALTSEQ|LIFO|JREF|JOIN|JFLD|JFILE|JDUPSEQ|JDFTVAL|FORMAT|FLTPCN|FIFO|FCFO|EDTCDE|EDTWRD|DYNSLT|DIGIT|DESCEND|DATSEP|DATFMT|CONCAT|COMP|COLHDG|CMP|CHKMSGID|CHECK|CCSID|ALTSEQ|ALL|ALIAS|ABSVAL)+)\\b"
+        },
+        {
+          "name": "dds.lf.comp",
+          "begin": "(?i)(?<=(.{44}))((?<=((COMP)\\())|(?<=((CMP)\\()))",
+          "end": "(?=(\\)))",
+          "patterns": [
+            {
+              "name": "keyword.other.dds.lf.comp.values",
+              "match": "(?i)(\\b(GE|LE|NG|GT|NL|LT|NE|EQ)\\b)"
+            },
+            {
+              "name": "constant.numeric.dds.lf",
+              "match": "\\b([0-9]+)\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.single.dds.lf",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "comment.line.dds.lf",
+          "match": "^.{5}(.)(\\*).*"
+        },
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "keyword.other.dds.lf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.dds.lf"
 }

--- a/syntaxes/dds.pf.tmLanguage.json
+++ b/syntaxes/dds.pf.tmLanguage.json
@@ -1,111 +1,124 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "DDS.PF",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#gutter"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.dds.pf",
-					"match": "^.{5}(.)(\\*).*"
-				}
-			]
-		},
-		"gutter": {
-			"patterns": [
-				{
-					"name": "comment.gutter",
-					"match": "^.{5}"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-                    "name": "constant.language.dds.pf",
-                    "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
-                },
-				{
-					"name": "constant.language.dds.pf.nametype",
-					"match": "(?i)(?<=^.{5}(A|\\s).{10})(R|K)"
-				},
-				{
-					"name": "constant.language.dds.pf.ref",
-					"match": "(?i)(?<=^.{5}(A|\\s).{22})R"
-				},
-				{
-					"name": "constant.language.dds.pf.len",
-					"match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
-				},
-				{
-					"name": "constant.language.dds.pf.datatype",
-					"match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|L|T|Z|H|J|E|O|G|5)"
-				},
-				{
-					"name": "constant.language.dds.pf.decpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{29})([0-9]|\\s){2}"
-				},
-				{
-					"name": "constant.language.dds.pf.use",
-					"match": "(?i)(?<=^.{5}(A|\\s).{31})(B)"
-				},
-                {
-                    "name": "constant.numeric.dds.pf",
-                    "match": "(\\b[0-9]+)|([0-9]*[.][0-9]*)"
-                }
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.other.dds.pf.spec",
-					"match": "(?i)(?<=^.{5})(A)"
-				},
-				{
-					"name": "keyword.other.dds.pf",
-					"match": "\\+"
-				},
-				{
-					"name": "keyword.other.dds.pf.funcs",
-					"match": "(?i)(?<=(.{44}))(?<=((?<=^.{5}[A|\\s]).{38}))(ZONE|VARLEN|VALUES|UNSIGNED|UNIQUE|TIMSEP|TIMFMT|TEXT|REFSHIFT|REFFLD|REF|RANGE|NOALTSEQ|LIFO|FORMAT|FLTPCN|FIFO|FCFO|EDTCDE|EDTWRD|DIGIT|DFT|DESCEND|DATSEP|DATFMT|COMP|COLHDG|CMP|CHKMSGID|CHECK|CCSID|ALWNULL|ALTSEQ|ALIAS|ABSVAL)\\b"
-				}
-			]
-		},
-		"identifiers": {
-			"patterns": [
-				{
-					"name": "identifier.other.dds.lf.identifiers",
-					"match": "[a-zA-Z_#$][a-zA-Z0-9_.#$]*"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.single.dds.pf",
-			"begin": "'",
-			"end": "'",
-			"patterns": [
-				{
-					"name": "keyword.other.dds.pf.spec",
-					"match": "(?i)(?<=^.{5})(A)"
-				}
-			]
-		}
-	},
-	"scopeName": "source.dds.pf"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DDS.PF",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#gutter"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.dds.pf",
+          "match": "^.{5}(.)(\\*).*"
+        }
+      ]
+    },
+    "gutter": {
+      "patterns": [
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "comment.block.line.dds",
+          "begin": "(?<=^.{80})",
+          "end": "\n"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.dds.pf",
+          "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
+        },
+        {
+          "name": "constant.language.dds.pf.nametype",
+          "match": "(?i)(?<=^.{5}(A|\\s).{10})(R|K)"
+        },
+        {
+          "name": "constant.language.dds.pf.ref",
+          "match": "(?i)(?<=^.{5}(A|\\s).{22})R"
+        },
+        {
+          "name": "constant.language.dds.pf.len",
+          "match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
+        },
+        {
+          "name": "constant.language.dds.pf.datatype",
+          "match": "(?i)(?<=^.{5}(A|\\s).{28})(P|S|B|F|A|L|T|Z|H|J|E|O|G|5)"
+        },
+        {
+          "name": "constant.language.dds.pf.decpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{29})([0-9]|\\s){2}"
+        },
+        {
+          "name": "constant.language.dds.pf.use",
+          "match": "(?i)(?<=^.{5}(A|\\s).{31})(B)"
+        },
+        {
+          "name": "constant.numeric.dds.pf",
+          "match": "(\\b[0-9]+)|([0-9]*[.][0-9]*)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.other.dds.pf.spec",
+          "match": "(?i)(?<=^.{5})(A)"
+        },
+        {
+          "name": "keyword.other.dds.pf",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.other.dds.pf.funcs",
+          "match": "(?i)(?<=(.{44}))(?<=((?<=^.{5}[A|\\s]).{38}))(ZONE|VARLEN|VALUES|UNSIGNED|UNIQUE|TIMSEP|TIMFMT|TEXT|REFSHIFT|REFFLD|REF|RANGE|NOALTSEQ|LIFO|FORMAT|FLTPCN|FIFO|FCFO|EDTCDE|EDTWRD|DIGIT|DFT|DESCEND|DATSEP|DATFMT|COMP|COLHDG|CMP|CHKMSGID|CHECK|CCSID|ALWNULL|ALTSEQ|ALIAS|ABSVAL)\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "identifier.other.dds.lf.identifiers",
+          "match": "[a-zA-Z_#$][a-zA-Z0-9_.#$]*"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.single.dds.pf",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "comment.line.dds.pf",
+          "match": "^.{5}(.)(\\*).*"
+        },
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "keyword.other.dds.pf.spec",
+          "match": "(?i)(?<=^.{5})(A)"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.dds.pf"
 }

--- a/syntaxes/dds.prtf.tmLanguage.json
+++ b/syntaxes/dds.prtf.tmLanguage.json
@@ -1,131 +1,144 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "DDS.PRTF",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#gutter"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.dds.prtf",
-					"match": "^.{5}(.)(\\*).*"
-				}
-			]
-		},
-		"gutter": {
-			"patterns": [
-				{
-					"name": "comment.gutter",
-					"match": "^.{5}"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-                    "name": "constant.language.dds.prtf",
-                    "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
-                },
-				{
-					"name": "constant.language.dds.prtf.andor",
-					"match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
-                },
-                {
-                    "name": "constant.language.dds.prtf.n01",
-					"match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.prtf.n02",
-					"match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
-                },
-                {
-                    "name": "constant.language.dds.prtf.n03",
-					"match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
-                }, 
-                {
-                    "name": "constant.language.dds.prtf.nameType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{10})R"
-                },
-                {
-                    "name": "constant.language.dds.prtf.ref",
-					"match": "(?i)(?<=^.{5}(A|\\s).{22})R"
-                },
-                {
-                    "name": "constant.language.dds.prtf.len",
-					"match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
-                },
-                {
-                    "name": "constant.language.dds.prtf.dataType",
-					"match": "(?i)(?<=^.{5}(A|\\s).{28})(A|F|G|L|O|S|T|Z)"
-                },
-                {
-                    "name": "constant.language.dds.prtf.decpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
-                },
-                {
-                    "name": "constant.language.dds.prtf.usage",
-					"match": "(?i)(?<=^.{5}(A|\\s).{31})O"
-                },
-                {
-                    "name": "constant.language.dds.prtf.locline",
-					"match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s|\\+){3}"
-                },
-                {
-                    "name": "constant.language.dds.prtf.locpos",
-					"match": "(?i)(?<=^.{5}(A|\\s).{35})([0-9]|\\s|\\+){3}"
-                },
-                {
-                    "name": "constant.numeric.dds.prtf",
-                    "match": "\\b([0-9]+)\\b"
-                }
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.other.dds.prtf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				},
-				{
-					"name": "keyword.other.dds.prtf",
-					"match": "\\+"
-				},
-                {
-                    "name": "keyword.other.dds.prtf.func", 
-                    "match": "((?i)(C(A|F)))[0-9]{2}"
-                },
-				{
-					"name": "keyword.other.dds.prtf.funcs",
-					"match": "(?i)(?<=(.{44}))(ZFOLD|UNISCRIPT|UNDERLINE|TXTRTT|TRNSPY|TIMSEP|TIMFMT|TIME|TEXT|STRPAGGRP|STAPLE|SPACEB|SPACEA|SKIPB|SKIPA|RELPOS|REFFLD|REF|PRTQLTY|POSITION|PAGSEG|PAGRTT|PAGNBR|OVERLAY|OUTBIN|MSGCON|LPI|LINE|INVMMAP|INVDTAMAP|INDTXT|INDARA|HIGHLIGHT|GDF|FORCE|FONTNAME|FONT|FNTCHRSET|FLTPCN|FLTFIXDEC|ENDPAGGRP|ENDPAGE|EDTWRD|EDTCDE|DUPLEX|DTASTMCMD|DRAWER|DOCIDXTAG|DLTEDT|DFT|DFNCHR|DATSEP|DATFMT|DATE|CVTDTA|CPI|COLOR|CHRSIZ|CHRID|CDEFNT|BOX|BLKFOLD|BARCODE|ALIAS|AFPRSC)\\b"
-                }
-			]
-		},
-		"strings": {
-			"name": "string.quoted.single.dds.prtf",
-			"begin": "'",
-			"end": "'",
-			"patterns": [
-				{
-					"name": "keyword.other.dds.prtf.spec",
-					"match": "(?i)(?<=^.{5})[A]"
-				}
-			]
-		}
-	},
-	"scopeName": "source.dds.prtf"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "DDS.PRTF",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#gutter"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.dds.prtf",
+          "match": "^.{5}(.)(\\*).*"
+        }
+      ]
+    },
+    "gutter": {
+      "patterns": [
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "comment.block.line.dds",
+          "begin": "(?<=^.{80})",
+          "end": "\n"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.dds.prtf",
+          "match": "(\\*)[a-zA-Z][a-zA-Z0-9]*"
+        },
+        {
+          "name": "constant.language.dds.prtf.andor",
+          "match": "(?i)(?<=^.{5}(A|\\s).{0})(A|O)"
+        },
+        {
+          "name": "constant.language.dds.prtf.n01",
+          "match": "(?i)(?<=^.{5}(A|\\s).{1})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.prtf.n02",
+          "match": "(?i)(?<=^.{5}(A|\\s).{4})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.prtf.n03",
+          "match": "(?i)(?<=^.{5}(A|\\s).{7})(N|\\s)[0-9]{2}"
+        },
+        {
+          "name": "constant.language.dds.prtf.nameType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{10})R"
+        },
+        {
+          "name": "constant.language.dds.prtf.ref",
+          "match": "(?i)(?<=^.{5}(A|\\s).{22})R"
+        },
+        {
+          "name": "constant.language.dds.prtf.len",
+          "match": "(?i)(?<=^.{5}(A|\\s).{23})[0-9|\\s]{5}"
+        },
+        {
+          "name": "constant.language.dds.prtf.dataType",
+          "match": "(?i)(?<=^.{5}(A|\\s).{28})(A|F|G|L|O|S|T|Z)"
+        },
+        {
+          "name": "constant.language.dds.prtf.decpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{29})[0-9|\\s]{2}"
+        },
+        {
+          "name": "constant.language.dds.prtf.usage",
+          "match": "(?i)(?<=^.{5}(A|\\s).{31})O"
+        },
+        {
+          "name": "constant.language.dds.prtf.locline",
+          "match": "(?i)(?<=^.{5}(A|\\s).{32})([0-9]|\\s|\\+){3}"
+        },
+        {
+          "name": "constant.language.dds.prtf.locpos",
+          "match": "(?i)(?<=^.{5}(A|\\s).{35})([0-9]|\\s|\\+){3}"
+        },
+        {
+          "name": "constant.numeric.dds.prtf",
+          "match": "\\b([0-9]+)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.other.dds.prtf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        },
+        {
+          "name": "keyword.other.dds.prtf",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.other.dds.prtf.func",
+          "match": "((?i)(C(A|F)))[0-9]{2}"
+        },
+        {
+          "name": "keyword.other.dds.prtf.funcs",
+          "match": "(?i)(?<=(.{44}))(ZFOLD|UNISCRIPT|UNDERLINE|TXTRTT|TRNSPY|TIMSEP|TIMFMT|TIME|TEXT|STRPAGGRP|STAPLE|SPACEB|SPACEA|SKIPB|SKIPA|RELPOS|REFFLD|REF|PRTQLTY|POSITION|PAGSEG|PAGRTT|PAGNBR|OVERLAY|OUTBIN|MSGCON|LPI|LINE|INVMMAP|INVDTAMAP|INDTXT|INDARA|HIGHLIGHT|GDF|FORCE|FONTNAME|FONT|FNTCHRSET|FLTPCN|FLTFIXDEC|ENDPAGGRP|ENDPAGE|EDTWRD|EDTCDE|DUPLEX|DTASTMCMD|DRAWER|DOCIDXTAG|DLTEDT|DFT|DFNCHR|DATSEP|DATFMT|DATE|CVTDTA|CPI|COLOR|CHRSIZ|CHRID|CDEFNT|BOX|BLKFOLD|BARCODE|ALIAS|AFPRSC)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.single.dds.prtf",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "comment.line.dds.prtf",
+          "match": "^.{5}(.)(\\*).*"
+        },
+        {
+          "name": "comment.gutter",
+          "match": "^.{1,5}"
+        },
+        {
+          "name": "keyword.other.dds.prtf.spec",
+          "match": "(?i)(?<=^.{5})[A]"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.dds.prtf"
 }

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -481,7 +481,7 @@
         },
         {
           "name": "comment.block.line.rpgle.fixed",
-          "begin": "(?i)(?<=((?<=^.{5}((H|F|D|I|C|O|P))).{74}))",
+          "begin": "(?<=^.{80})",
           "end": "\n"
         }
       ]

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -18,7 +18,7 @@
           "include": "#freeSQL"
         },
         {
-          "include": "#rpglecommon"
+          "include": "#freerpglecommon"
         },
         {
           "include": "#freeformat"
@@ -37,7 +37,7 @@
       "include": "#fixedSQL"
     },
     {
-      "include": "#freeSQL"
+      "include": "#fixedfreeSQL"
     },
     {
       "include": "#precompiler"
@@ -55,7 +55,7 @@
       "include": "#fixedformat"
     },
     {
-      "include": "#freeformat"
+      "include": "#fixedfreeformat"
     }
   ],
   "repository": {
@@ -92,7 +92,14 @@
       ]
     },
     "rpglecommon": {
+      "comment": "Used in fixed-format and /FREE-within-fixed contexts. Includes gutter-aware fixedcomment and fixedstrings.",
       "patterns": [
+        {
+          "include": "#fixedcomment"
+        },
+        {
+          "include": "#fixedstrings"
+        },
         {
           "include": "#comments"
         },
@@ -110,9 +117,32 @@
         },
         {
           "include": "#keywords"
-        },
+        }
+      ]
+    },
+    "freerpglecommon": {
+      "comment": "Used in **FREE (fully free-format) contexts where no sequence-number gutter is present.",
+      "patterns": [
         {
           "include": "#strings"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#freedefkeywords"
+        },
+        {
+          "include": "#sqlvariables"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#precompiler"
+        },
+        {
+          "include": "#keywords"
         }
       ]
     },
@@ -171,6 +201,25 @@
       ]
     },
     "freeidentifiers": {
+      "comment": "Used in **FREE contexts. Delegates to freerpglecommon.",
+      "patterns": [
+        {
+          "name": "variable.other.rpgle.free.definition.identifier",
+          "begin": "[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*",
+          "end": "(?=\n)",
+          "patterns": [
+            {
+              "include": "#freedefkeywords"
+            },
+            {
+              "include": "#freerpglecommon"
+            }
+          ]
+        }
+      ]
+    },
+    "fixedfreeidentifiers": {
+      "comment": "Used in fixed-format and /FREE-within-fixed contexts. Delegates to rpglecommon.",
       "patterns": [
         {
           "name": "variable.other.rpgle.free.definition.identifier",
@@ -188,6 +237,109 @@
       ]
     },
     "freeformat": {
+      "comment": "Free-format statements for **FREE (fully free-format) source. Uses freerpglecommon throughout.",
+      "patterns": [
+        {
+          "name": "rpgle.free.control",
+          "begin": "(?i)\\b(?=CTL\\-OPT)\\b",
+          "end": ";",
+          "patterns": [
+            {
+              "include": "#freerpglecommon"
+            },
+            {
+              "name": "storage.type.rpgle.free.control",
+              "match": "(?i)\\b(CTL\\-OPT)\\b"
+            },
+            {
+              "name": "entity.name.function.rpgle.free.control.keywords",
+              "match": "(?i)\\b(VALIDATE|USRPRF|TRUNCNBR|TIMFMT|THREAD|TEXT|STGMDL|SRTSEQ|REQPREXP|PRFDTA|PGMINFO|OPTION|OPTIMIZE|OPENOPT|NOMAIN|MAIN|LANGID|INTPREC|INDENT|GENLVL|FTRANS|FORMSALIGN|FLTDIV|FIXNBR|EXTBININT|EXPROPTS|ENBPFRCOL|DFTNAME|DFTACTGRP|DECPREC|DECEDIT|DEBUG|DATFMT|DATEYY|DATEDIT|DCLOPT|CVTOPT|CURSYM|COPYRIGHT|COPYNEST|CHARCOUNTTYPES|CHARCOUNT|CCSIDCVT|CCSID|BNDDIR|AUT|ALWNULL|ALTSEQ|ACTGRP|ALLOC)\\b"
+            }
+          ]
+        },
+        {
+          "name": "rpgle.free.file",
+          "begin": "(?i)\\b(?=DCL\\-F)\\b",
+          "end": ";",
+          "patterns": [
+            {
+              "include": "#freerpglecommon"
+            },
+            {
+              "name": "storage.type.rpgle.free.file",
+              "match": "(?i)\\b(DCL\\-F)\\b"
+            },
+            {
+              "name": "entity.name.function.rpgle.free.file.keywords",
+              "match": "(?i)\\b(WORKSTN|USROPN|USAGE|TIMFMT|TEMPLATE|STATIC|SPECIAL|SLN|SFILE|SEQ|SAVEIND|SAVEDS|RENAME|RECNO|RAFDATA|QUALIFIED|PRTCTL|PRINTER|PREFIX|PLIST|PGMNAME|PASS|OFLIND|MAXDEV|LIKEFILE|KEYLOC|KEYED|INFSR|INFDS|INDDS|INCLUDE|IGNORE|HANDLER|FORMOFL|FORMLEN|EXTMBR|EXTIND|EXTFILE|EXTDESC|DISK|DEVID|DATFMT|DATA|COMMIT|CHARCOUNT|BLOCK|ALIAS)\\b"
+            }
+          ]
+        },
+        {
+          "name": "storage.type.rpgle.free.definition.subr",
+          "match": "(?i)\\b(BEG|END)SR\\b"
+        },
+        {
+          "name": "rpgle.free.definition.simple",
+          "begin": "(?i)(?=(\\b(DCL\\-)(S|C|PARM|SUBF)\\b))",
+          "end": "\n",
+          "patterns": [
+            {
+              "name": "storage.type.rpgle.free.definition.simple",
+              "match": "(?i)\\b(DCL\\-)(S|C|PARM|SUBF)\\b"
+            },
+            {
+              "include": "#freeidentifiers"
+            },
+            {
+              "name": "comment.line.rpgle.free",
+              "match": "(\/\/).*"
+            }
+          ]
+        },
+        {
+          "name": "rpgle.free.definition.complex",
+          "begin": "(?i)(?=(\\b(DCL\\-)(DS|ENUM|PROC|PR|PI)\\b))",
+          "end": "\n",
+          "patterns": [
+            {
+              "name": "storage.type.rpgle.free.definition.complex.dcl",
+              "match": "(?i)\\b(DCL\\-)(DS|ENUM|PROC|PR|PI)\\b"
+            },
+            {
+              "name": "storage.type.rpgle.free.definition.complex.dcl",
+              "match": "(?i)\\b(END\\-)(DS|ENUM|PROC|PR|PI)\\b"
+            },
+            {
+              "include": "#freedefkeywords"
+            },
+            {
+              "include": "#freerpglecommon"
+            },
+            {
+              "name": "variable.other.rpgle.free.definition.identifier",
+              "match": "\\b[a-zA-Z_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ][a-zA-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ]*\\b"
+            }
+          ]
+        },
+        {
+          "name": "storage.type.rpgle.free.definition.complex.dcl",
+          "match": "(?i)\\b(END\\-)(DS|ENUM|PROC|PR|PI)\\b"
+        },
+        {
+          "name": "keyword.other.rpgle.free",
+          "match": "(?i)(?<![A-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ])(ACQ|ADDUR|ALLOC|AND|BEGSR|CALLP|CHAIN|CLEAR|CLOSE|COMMIT|DATA\\-GEN|DATA\\-INTO|DEALLOC|DELETE|DOU|DOW|DSPLY|DUMP|ELSEIF|ELSE|ENDDO|ENDFOR|ENDIF|ENDMON|ENDSL|ENDSR|EVAL\\-CORR|EVALR|EVAL|EXCEPT|EXFMT|EXSR|FEOD|FOR\\-EACH|FOR|FORCE|IF|IN|ITER|LEAVESR|LEAVE|MONITOR|NEXT|ON\\-ERROR|ON\\-EXCP|ON\\-EXIT|OPEN|OR|OTHER|OUT|POST|READC|READE|READP|READPE|READ|REL|RESET|RETURN|ROLBK|SELECT|SETGT|SETLL|SHTDN|SND\\-MSG|SORTA|TEST|UNLOCK|UPDATE|WHEN\\-IN|WHEN\\-IS|WHEN|WRITE|XML\\-INTO|XML\\-SAX)(?![-A-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ])"
+        },
+        {
+          "include": "#freeidentifiers"
+        },
+        {
+          "include": "#freerpglecommon"
+        }
+      ]
+    },
+    "fixedfreeformat": {
+      "comment": "Free-format statements for fixed-format source (including mixed-mode files). Uses rpglecommon throughout for gutter awareness.",
       "patterns": [
         {
           "name": "rpgle.free.control",
@@ -239,7 +391,7 @@
               "match": "(?i)\\b(DCL\\-)(S|C|PARM|SUBF)\\b"
             },
             {
-              "include": "#freeidentifiers"
+              "include": "#fixedfreeidentifiers"
             },
             {
               "name": "comment.line.rpgle.free",
@@ -281,7 +433,7 @@
           "match": "(?i)(?<![A-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ])(ACQ|ADDUR|ALLOC|AND|BEGSR|CALLP|CHAIN|CLEAR|CLOSE|COMMIT|DATA\\-GEN|DATA\\-INTO|DEALLOC|DELETE|DOU|DOW|DSPLY|DUMP|ELSEIF|ELSE|ENDDO|ENDFOR|ENDIF|ENDMON|ENDSL|ENDSR|EVAL\\-CORR|EVALR|EVAL|EXCEPT|EXFMT|EXSR|FEOD|FOR\\-EACH|FOR|FORCE|IF|IN|ITER|LEAVESR|LEAVE|MONITOR|NEXT|ON\\-ERROR|ON\\-EXCP|ON\\-EXIT|OPEN|OR|OTHER|OUT|POST|READC|READE|READP|READPE|READ|REL|RESET|RETURN|ROLBK|SELECT|SETGT|SETLL|SHTDN|SND\\-MSG|SORTA|TEST|UNLOCK|UPDATE|WHEN\\-IN|WHEN\\-IS|WHEN|WRITE|XML\\-INTO|XML\\-SAX)(?![-A-Z0-9_#@$§ÆØÅÄÖ£Ñ¥àÐŞİ])"
         },
         {
-          "include": "#freeidentifiers"
+          "include": "#fixedfreeidentifiers"
         },
         {
           "include": "#rpglecommon"
@@ -289,6 +441,7 @@
       ]
     },
     "tempfreeformat": {
+      "comment": "Handles /FREE.../END-FREE blocks within fixed-format source. Uses fixedfreeformat and fixedfreeSQL for gutter awareness.",
       "patterns": [
         {
           "begin": "(?i)(?=((\\/FREE\\b)))",
@@ -302,10 +455,10 @@
               "include": "#rpglecommon"
             },
             {
-              "include": "#freeformat"
+              "include": "#fixedfreeformat"
             },
             {
-              "include": "#freeSQL"
+              "include": "#fixedfreeSQL"
             }
           ]
         },
@@ -924,6 +1077,7 @@
       ]
     },
     "strings": {
+      "comment": "String literals for **FREE (fully free-format) source. No gutter awareness needed.",
       "patterns": [
         {
           "name": "string.other.rpgle.hex",
@@ -937,12 +1091,67 @@
         }
       ]
     },
+    "fixedstrings": {
+      "comment": "String literals for fixed-format source. Nests fixedcomment so the sequence-number gutter on continuation lines is not consumed as string content.",
+      "patterns": [
+        {
+          "name": "string.other.rpgle.hex",
+          "begin": "(?i)x'",
+          "end": "'",
+          "patterns": [
+            {
+              "include": "#fixedcomment"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.rpgle",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "include": "#fixedcomment"
+            }
+          ]
+        }
+      ]
+    },
     "freeSQL": {
+      "comment": "EXEC SQL...;  blocks in **FREE (fully free-format) source.",
       "patterns": [
         {
           "begin": "(?i)(?=(^\\s*(EXEC)\\s+(SQL)\\b))",
           "end": "(?=(;))",
           "patterns": [
+            {
+              "name": "keyword.other.rpgle.sql",
+              "match": "(?i)(EXEC)\\s+(SQL)\\b"
+            },
+            {
+              "include": "#sqlcommon"
+            }
+          ]
+        },
+        {
+          "name": "comment.line.rpgle.sql",
+          "match": "(?<=(;))\\s*.*"
+        },
+        {
+          "name": "rpgle.free.sql.end",
+          "match": ";"
+        }
+      ]
+    },
+    "fixedfreeSQL": {
+      "comment": "EXEC SQL...;  blocks in fixed-format source (including /FREE blocks). Nests fixedcomment so the sequence-number gutter on continuation lines is not consumed as SQL content.",
+      "patterns": [
+        {
+          "begin": "(?i)(?=(^\\s*(EXEC)\\s+(SQL)\\b))",
+          "end": "(?=(;))",
+          "patterns": [
+            {
+              "include": "#fixedcomment"
+            },
             {
               "name": "keyword.other.rpgle.sql",
               "match": "(?i)(EXEC)\\s+(SQL)\\b"

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -1077,28 +1077,45 @@
       ]
     },
     "strings": {
-      "comment": "String literals for **FREE (fully free-format) source. No gutter awareness needed.",
-      "patterns": [
-        {
-          "name": "string.other.rpgle.hex",
-          "begin": "(?i)x'",
-          "end": "'"
-        },
-        {
-          "name": "string.quoted.single.rpgle",
-          "begin": "'",
-          "end": "'"
-        }
-      ]
-    },
-    "fixedstrings": {
-      "comment": "String literals for fixed-format source. Nests fixedcomment so the sequence-number gutter on continuation lines is not consumed as string content.",
+      "comment": "String literals for **FREE (fully free-format) source. A // comment line nested first so any ' inside a comment cannot prematurely close the string.",
       "patterns": [
         {
           "name": "string.other.rpgle.hex",
           "begin": "(?i)x'",
           "end": "'",
           "patterns": [
+            {
+              "name": "comment.line.rpgle.free",
+              "match": "^\\s*//.*"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.rpgle",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "comment.line.rpgle.free",
+              "match": "^\\s*//.*"
+            }
+          ]
+        }
+      ]
+    },
+    "fixedstrings": {
+      "comment": "String literals for fixed-format source. A // free-format comment handler is nested first to consume any comment line (including any ' it contains) before the gutter-only fixedcomment rule runs.",
+      "patterns": [
+        {
+          "name": "string.other.rpgle.hex",
+          "begin": "(?i)x'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "comment.line.rpgle.free",
+              "begin": "^.{5}.\\s*//",
+              "end": "\\n"
+            },
             {
               "include": "#fixedcomment"
             }
@@ -1109,6 +1126,11 @@
           "begin": "'",
           "end": "'",
           "patterns": [
+            {
+              "name": "comment.line.rpgle.free",
+              "begin": "^.{5}.\\s*//",
+              "end": "\\n"
+            },
             {
               "include": "#fixedcomment"
             }

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -477,7 +477,7 @@
         },
         {
           "name": "comment.gutter",
-          "match": "^.{5}"
+          "match": "^.{1,5}"
         },
         {
           "name": "comment.block.line.rpgle.fixed",

--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -1146,7 +1146,7 @@
       "comment": "EXEC SQL...;  blocks in fixed-format source (including /FREE blocks). Nests fixedcomment so the sequence-number gutter on continuation lines is not consumed as SQL content.",
       "patterns": [
         {
-          "begin": "(?i)(?=(^\\s*(EXEC)\\s+(SQL)\\b))",
+          "begin": "(?i)(?=(^.{5}\\s*(EXEC)\\s+(SQL)\\b))",
           "end": "(?=(;))",
           "patterns": [
             {

--- a/tests/issues/168.dspf
+++ b/tests/issues/168.dspf
@@ -1,0 +1,21 @@
+R11  A* 07/16/11 Dev1     - Update language
+R10  A* 06/04/09 Dev1     - Removed hard coding
+     A*
+     A                                      DSPSIZ(24 80 *DS3)
+     A                                      PRINT
+     A                                      CA03(03 'F3=Exit')
+     A                                      CF12(12 'F12=Previous')
+     A          R FIRST
+     A                                      TEXT('Test inquiry subfile option d-
+R10  A                                      isplay')
+R10  A                                  2  5'Test to see if data Libraries that-
+R11  A*R10                                   were sent in are good'
+R11  A                                       we received in are good'
+     A                                  5  5'Prv. dat Library'
+     A            OLDDAT        10A  B  5 32
+     A                                  6  5'Next dat Library'
+     A            DATLIB        10A  B  6 32
+     A                                 23  7'F3 = Exit'
+     A                                      COLOR(BLU)
+     A                                 23 61'Enter to Continue'
+     A                                      COLOR(BLU)

--- a/tests/issues/168.rpgle
+++ b/tests/issues/168.rpgle
@@ -1,0 +1,16 @@
+     H option(*srcstmt : *nodebugio)
+
+       // commeents mid string
+     D sqlStatement    s           2000a
+
+25001C                   eval      sqlStatement = 'delete +
+M01  C*                                            testSchema/terstTable +
+25001C                                             testSchema/testTable +
+25001C                                             where flag <> ''Y'''
+
+25001    sqlStatement = 'delete +
+M01                     // testSchema/terstTable +
+25001                   testSchema/testTable +
+25001                   where flag <> ''Y''';
+
+         *inlr = *on ;

--- a/tests/issues/168F.rpgle
+++ b/tests/issues/168F.rpgle
@@ -1,0 +1,13 @@
+**FREE
+
+ctl-opt option(*srcstmt : *nodebugio);
+
+// commeents mid string
+dcl-s sqlStatement char(2000);
+
+sqlStatement = 'delete +                        
+                //M01 testSchema/terstTable +      
+                testSchema/testTable +          
+                where flag <> ''Y''';           
+
+*inlr = *on ;

--- a/tests/issues/170.sqlrpgle
+++ b/tests/issues/170.sqlrpgle
@@ -1,0 +1,99 @@
+     H option(*srcstmt : *nodebugio) bnddir('QC2LE')
+
+25001  // 07/07/26 Dev2 #5555.55 - Update
+M01    // 04/25/16 Dev1 #12345 - Changes
+
+       // This example focuses on left and right side comments when not using **FREE
+
+M01  FMYFILE    if   e           k disk    usropn extfile(pathFILE)             LIB/MYFILE
+       // Program status data structure
+M01  D pgmDS          SDS                  QUALIFIED
+M01  D  Library               81     90                                         Pgm Library
+M01  D  JOB_NAME             244    253                                         Job name
+M01  D  USER                 254    263                                         User name
+     D  JOB_NUM              264    269S 0                                      Job number
+25001D  JOB_NUMc             264    269                                         Job number
+     D  Program              334    343                                         Program Name
+
+         exec sql
+           Declare csrTheCursor Cursor for
+M01         select A.FIELD1, A.FIELD2
+             from MYFILE A
+             join YOURFILE B
+                  ON A.KEY1     = B.KEY1  AND
+                     A.KEY2     = B.KEY2
+25001       where A.KEY1 = :MasterKey
+25001         and A.KEY2 not in ('MONDAY', 'FRIDAY')
+M01           and A.STATUS <> 'I'
+25001       order by MONTH(A.KEY1), A.KEY2;
+         Exec SQL Open csrTheCursor;
+
+       //-------------------------------------------------------------
+       //Begin Subroutine - Contacts
+       //-------------------------------------------------------------
+       begsr $Contacts;
+M01
+M01                                                                             Comment
+                                                                                Program Name
+25001      dou $ChkSQLState(SQLSTT);
+25001        Exec SQL select CKEY, NKEY,
+25001                        RMCNAM1, RMCPHO1, RMCEMA1,                         Comment in SQL
+25001                        RMCNAM2, RMCPHO2, RMCEMA2,
+25001                        RMCNAM3, RMCPHO3, RMCEMA3
+25001                   into :dsContact
+25001                   from CONTACTS
+25001                  where CKEY = :@1CKEY
+25001                    and NKEY = :@1NKEY;
+25001      enddo;
+25001
+M01
+       exec SQL insert into library/testa                                       values
+        values('X', 'Y', 'Z');
+       endsr;
+25001  //-------------------------------------------------------------
+25001  //$BuildEmail - Build Email
+25001  //-------------------------------------------------------------
+25001  dcl-proc $BuildEmail;
+M01
+25001    dcl-s message char(1000);
+25001    dcl-s contacts char(100);
+25001    dcl-s emails char(200);
+25001    dcl-s count int(20);
+25001    dcl-s missingemail ind;
+25001
+25001    dcl-ds dsEmailContacts;
+25001      FIRST1  char(30);
+25001      RMCNAM1 char(30);
+25001      RMCEMA1 char(50);
+25001      FIRST2  char(30);
+25001      RMCNAM2 char(30);
+25001      RMCEMA2 char(50);
+25001      FIRST3  char(30);
+25001      RMCNAM3 char(30);
+25001      RMCEMA3 char(50);
+25001    END-DS;
+M01
+25001    dcl-c cmd_STRPCCMD 'STRPCCMD PCCMD(''%'') PAUSE(*NO)';
+25001    dcl-c msg_HEADER 'start outlook.exe /c ipm.note /m "%+
+25001                      ?Subject=% - % &Body=%,%';
+25001    dcl-c msg_SUBJECTA 'Event 1';
+25001    dcl-c msg_SUBJECTR 'Event 2';
+25001    dcl-c msg_AFTER '%0A%0AAs this is a very long message that, +
+25001                     I would like to send to you about the +
+25001                     process that is happening soon. Please let me +       Comment
+25001                     know if you are ready to proceed.%0A%0ASincerely,"';
+25001
+25001    sqlStatement = 'delete +
+M01                     // testSchema/terstTable +
+25001                   testSchema/testTable +
+25001                   where flag <> ''Y''';
+25001
+25001
+25001  end-proc;
+25001
+
+M01
+
+TEST
+
+25001 /end-free


### PR DESCRIPTION
…ormat source

## Problem

In fixed-format RPGLE source files (and `/FREE`...`/END-FREE` blocks within them), the 5-character sequence-number gutter at the start of each line was being consumed by string literal and `EXEC SQL` token matchers. This caused incorrect colorization on any multi-line string or SQL statement whose continuation lines started with sequence/date/name gutter characters.

The root cause is that the existing `#strings` and `#freeSQL` rules have no awareness of the fixed-format gutter, and `#rpglecommon` (used everywhere) passed those gutter-unaware rules into fixed-format contexts.

## Solution

Introduces a clean split between **free-format** and **fixed-format** contexts:

| New rule | Purpose |
|---|---|
| `#freerpglecommon` | Mirrors the original `rpglecommon` — used only in `**FREE` files where there is no gutter | | `#fixedstrings` | Nests `#fixedcomment` inside both string patterns so the gutter is tokenized before string content on continuation lines | | `#fixedfreeformat` | Copy of `#freeformat` that delegates to `#rpglecommon` (gutter-aware) instead of `#freerpglecommon` — used in fixed-format and mixed-mode files | | `#fixedfreeidentifiers` | Copy of `#freeidentifiers` that delegates to `#rpglecommon` — used in `#fixedfreeformat` | | `#fixedfreeSQL` | Copy of `#freeSQL` that nests `#fixedcomment` — used for `EXEC SQL...;` in fixed-format and `/FREE` blocks |

`#rpglecommon` is updated to use `#fixedstrings` and include `#fixedcomment`, making it safe for all fixed-format contexts. `#freerpglecommon` retains the original behavior for `**FREE` files.

`#tempfreeformat` (which handles `/FREE`...`/END-FREE` blocks) is updated to use `#fixedfreeformat` and `#fixedfreeSQL` so gutter awareness is maintained throughout the block.

## Files changed

- `syntaxes/rpgle.tmLanguage.json`