### PR TITLE
fixes test-fullfree.rpgle regression

### DIFF
--- a/syntaxes/rpgle.tmLanguage.json
+++ b/syntaxes/rpgle.tmLanguage.json
@@ -18,6 +18,25 @@
           "include": "#freeSQL"
         },
         {
+          "name": "rpgle.fixed.embedded",
+          "begin": "(?=^\\s{5}[HFDICOPhfdicop](?![a-z]))",
+          "end": "(?<=\\n)",
+          "patterns": [
+            {
+              "include": "#fixedcomment"
+            },
+            {
+              "include": "#fixedSQL"
+            },
+            {
+              "include": "#fixedformat"
+            },
+            {
+              "include": "#rpglecommon"
+            }
+          ]
+        },
+        {
           "include": "#rpglecommon"
         },
         {


### PR DESCRIPTION
Fixes regression found in https://github.com/barrettotte/vscode-ibmi-languages/issues/177.
Also ran through all existing rpgle source files to verify this doesn't regress anything else

This is prep work for introducing unit testing to make development/maintenance easier.
Once this is fixed, unit tests can compare against baseline.

Apologies for my lack of contributions here, I've been squirrel brained. As always I really appreciate your help/maintenance of this.

Before:
<img width="1063" height="466" alt="image" src="https://github.com/user-attachments/assets/7bf85267-5c90-49f0-b1d3-603f17e334ad" />

After:
<img width="1063" height="466" alt="image" src="https://github.com/user-attachments/assets/bf738052-89e8-45f6-8376-4fba6e3193ca" />
